### PR TITLE
feat: warn when emit.inject is configured but never injected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Build-time warning when `emit.inject` is configured but Vite's `transformIndexHtml` is never called (e.g. SvelteKit, VitePress build, some Astro adapters). The plugin now logs a clear message instead of silently producing files with no `<link>` tags injected. ([#1](https://github.com/kjanat/vite-svg-to-ico/issues/1))
+
 ## [2.1.0] - 2026-05-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-svg-to-ico",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "A Vite plugin that converts SVG files to ICO format during the build process.",
 	"keywords": [
 		"vite-plugin",

--- a/src/index.ts
+++ b/src/index.ts
@@ -583,8 +583,15 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 			 * happens with frameworks (SvelteKit, VitePress build, some Astro
 			 * adapters) that render HTML outside Vite's pipeline, causing the
 			 * `<link>` injection to silently no-op while files are still emitted.
+			 *
+			 * Multi-environment Vite builds (SvelteKit drives client + ssr) call
+			 * `closeBundle` per environment; only the client environment ever
+			 * triggers `transformIndexHtml`, so the warning is scoped there to
+			 * avoid duplicate output.
 			 */
-			closeBundle() {
+			closeBundle(this: { environment?: { name?: string } }) {
+				const envName = this.environment?.name;
+				if (envName && envName !== 'client') return;
 				if (injectMode && !buildTransformIndexHtmlCalled) {
 					logger?.warn(
 						`[svg-to-ico] inject: '${injectMode}' was requested but transformIndexHtml was never called during build. `

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,8 @@ export type {
 export default function svgToIco(opts: PluginOptions): Plugin[] {
 	let generatedIco: Buffer | null = null;
 	let generatedPngs: SizedPng[] | null = null;
-	let logger: { info: (msg: string) => void } | null = null;
+	let logger: import('vite').Logger | null = null;
+	let buildTransformIndexHtmlCalled = false;
 
 	const {
 		input,
@@ -560,6 +561,7 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 			},
 
 			transformIndexHtml(html) {
+				buildTransformIndexHtmlCalled = true;
 				if (!injectMode) return;
 
 				const cleaned = html.replace(INJECT_ICON_LINK_RE, '');
@@ -567,6 +569,16 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 					html: cleaned,
 					tags: faviconTags({ base: resolvedBase }),
 				};
+			},
+
+			closeBundle() {
+				if (injectMode && !buildTransformIndexHtmlCalled) {
+					logger?.warn(
+						`[svg-to-ico] inject: '${injectMode}' was requested but transformIndexHtml was never called during build. `
+							+ `This happens with frameworks (SvelteKit, VitePress build, some Astro adapters) that bypass Vite's HTML pipeline. `
+							+ `Add favicon <link> tags manually to your framework's HTML template or head config — the generated files are still emitted correctly.`,
+					);
+				}
 			},
 		},
 	] satisfies Plugin[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -561,6 +561,11 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 				}
 			},
 
+			/**
+			 * Strip existing icon `<link>` tags from the HTML and append the
+			 * configured favicon tag set. Records that the hook fired so
+			 * {@link closeBundle} can detect frameworks that bypass this pipeline.
+			 */
 			transformIndexHtml(html) {
 				buildTransformIndexHtmlCalled = true;
 				if (!injectMode) return;
@@ -572,6 +577,13 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 				};
 			},
 
+			/**
+			 * Surface a warning when `emit.inject` was configured but
+			 * `transformIndexHtml` was never called during this build cycle. This
+			 * happens with frameworks (SvelteKit, VitePress build, some Astro
+			 * adapters) that render HTML outside Vite's pipeline, causing the
+			 * `<link>` injection to silently no-op while files are still emitted.
+			 */
 			closeBundle() {
 				if (injectMode && !buildTransformIndexHtmlCalled) {
 					logger?.warn(

--- a/src/index.ts
+++ b/src/index.ts
@@ -508,6 +508,7 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 			enforce: 'post',
 
 			async buildStart() {
+				buildTransformIndexHtmlCalled = false;
 				const I = new Instrumentation();
 				I.start('Generate ICO (build)');
 

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -163,6 +163,23 @@ describe('build plugin: inject-no-op warning', () => {
 		expect(warns).toHaveLength(0);
 	});
 
+	it('does not warn when called in a non-client Vite environment (e.g. SvelteKit ssr)', () => {
+		const { logger, warns } = mockLogger();
+		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: 'minimal' } }, logger);
+		// Simulate Vite 6+ Environment API: closeBundle fires per environment;
+		// SSR-side firing must not duplicate the warning.
+		build.closeBundle.call({ environment: { name: 'ssr' } });
+		expect(warns).toHaveLength(0);
+	});
+
+	it('warns once in client env when called for both client and ssr', () => {
+		const { logger, warns } = mockLogger();
+		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: 'minimal' } }, logger);
+		build.closeBundle.call({ environment: { name: 'client' } });
+		build.closeBundle.call({ environment: { name: 'ssr' } });
+		expect(warns).toHaveLength(1);
+	});
+
 	it('resets transformIndexHtml-called flag between build cycles (watch mode)', async () => {
 		const { logger, warns } = mockLogger();
 		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: 'minimal' } }, logger);

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -162,4 +162,31 @@ describe('build plugin: inject-no-op warning', () => {
 		build.closeBundle();
 		expect(warns).toHaveLength(0);
 	});
+
+	it('resets transformIndexHtml-called flag between build cycles (watch mode)', async () => {
+		const { logger, warns } = mockLogger();
+		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: 'minimal' } }, logger);
+
+		// Cycle 1: transformIndexHtml fires (vanilla) → no warning.
+		await build.buildStart.call({
+			emitFile: () => {},
+			error: (m: string) => {
+				throw new Error(m);
+			},
+		});
+		build.transformIndexHtml('<html><head></head></html>');
+		build.closeBundle();
+		expect(warns).toHaveLength(0);
+
+		// Cycle 2: hook doesn't fire (framework swap mid-watch). Flag must have reset.
+		await build.buildStart.call({
+			emitFile: () => {},
+			error: (m: string) => {
+				throw new Error(m);
+			},
+		});
+		build.closeBundle();
+		expect(warns).toHaveLength(1);
+		expect(warns[0]).toContain('transformIndexHtml was never called');
+	});
 });

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -117,3 +117,49 @@ describe('dev option', () => {
 		expect(() => svgToIco({ input: FIXTURE, dev: { hmr: false } })).not.toThrow();
 	});
 });
+
+describe('build plugin: inject-no-op warning', () => {
+	function mockLogger() {
+		const warns: string[] = [];
+		const logger = {
+			info: () => {},
+			warn: (msg: string) => warns.push(msg),
+			warnOnce: (msg: string) => warns.push(msg),
+			error: () => {},
+			clearScreen: () => {},
+			hasErrorLogged: () => false,
+			hasWarned: false,
+		};
+		return { logger, warns };
+	}
+
+	function getBuildPlugin(opts: Parameters<typeof svgToIco>[0], logger: ReturnType<typeof mockLogger>['logger']) {
+		const plugins = svgToIco(opts);
+		(plugins[0] as any).configResolved({ root: '/tmp', base: '/', logger });
+		return plugins.find((p) => p.name === 'svg-to-ico:build') as any;
+	}
+
+	it('warns when inject is set but transformIndexHtml never fires', () => {
+		const { logger, warns } = mockLogger();
+		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: 'minimal' } }, logger);
+		build.closeBundle();
+		expect(warns).toHaveLength(1);
+		expect(warns[0]).toContain("inject: 'minimal' was requested");
+		expect(warns[0]).toContain('transformIndexHtml was never called');
+	});
+
+	it('does not warn when transformIndexHtml fires', () => {
+		const { logger, warns } = mockLogger();
+		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: 'full' } }, logger);
+		build.transformIndexHtml('<html><head></head><body></body></html>');
+		build.closeBundle();
+		expect(warns).toHaveLength(0);
+	});
+
+	it('does not warn when inject is disabled', () => {
+		const { logger, warns } = mockLogger();
+		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: false } }, logger);
+		build.closeBundle();
+		expect(warns).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

Closes part 1 of #1 — turns the silent failure into a loud one.

When a user sets `emit.inject` but the host framework bypasses Vite's HTML pipeline (SvelteKit, VitePress build, some Astro adapters), the plugin's `transformIndexHtml` is never called and no `<link>` tags ever appear in the output. Previously this happened silently — files were emitted, no error, no warning, no `<link>` tags.

The build plugin now tracks whether `transformIndexHtml` fired and emits a `logger.warn` in `closeBundle` when `inject` was requested but the hook never ran.

- Closes #4

## Changes

- `src/index.ts`: track `buildTransformIndexHtmlCalled` flag, warn in `closeBundle`. Widen `logger` type from `{ info }` to `vite#Logger`.
- `tests/plugin.test.ts`: 3 new tests covering warn-fires / warn-skipped-when-called / warn-skipped-when-disabled.
- `CHANGELOG.md`: Unreleased entry.

## Out of scope

Actual SvelteKit/VitePress support (request 2 in #1) — follow-up PR stacked on this one: #3.

## Test plan

- [x] `bun test` — 77 pass, 0 fail
- [x] `bun --bun typecheck` — clean
- [x] Verify warning surfaces against a real SvelteKit project (reviewer)