### PR TITLE
feat: emit.injectScan for post-build HTML rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Build-time warning when `emit.inject` is configured but Vite's `transformIndexHtml` is never called (e.g. SvelteKit, VitePress build, some Astro adapters). The plugin now logs a clear message instead of silently producing files with no `<link>` tags injected. ([#1](https://github.com/kjanat/vite-svg-to-ico/issues/1))
+- `emit.injectScan` option (`string | string[]`) — explicit list of HTML files (resolved from project root) to rewrite in `closeBundle` after the build. Strips existing `<link rel="icon">` tags and inserts the configured favicon tag set before `</head>`. Use for frameworks that bypass Vite's HTML pipeline (SvelteKit `build/index.html`, VitePress prerendered pages). Requires `emit.inject` to also be set. ([#1](https://github.com/kjanat/vite-svg-to-ico/issues/1))
 
 ## [2.1.0] - 2026-05-12
 

--- a/src/html.ts
+++ b/src/html.ts
@@ -88,3 +88,40 @@ export function buildFaviconTags(opts: FaviconTagOptions): HtmlTagDescriptor[] {
  * Intentionally does **not** match `apple-touch-icon` so those are preserved.
  */
 export const INJECT_ICON_LINK_RE = /\s*<link\b[^>]*\brel\s*=\s*["'](?:shortcut\s+)?icon["'][^>]*>\s*/gi;
+
+/** Render a Vite {@link HtmlTagDescriptor} as a self-closing HTML string. */
+export function renderTag(tag: HtmlTagDescriptor): string {
+	const attrs = tag.attrs
+		? Object.entries(tag.attrs)
+			.filter(([, v]) => v !== false && v !== undefined && v !== null)
+			.map(([k, v]) => v === true ? k : `${k}="${escapeAttr(String(v))}"`)
+			.join(' ')
+		: '';
+	const open = attrs ? `<${tag.tag} ${attrs}>` : `<${tag.tag}>`;
+	if (tag.children == null) return open;
+	const children = typeof tag.children === 'string'
+		? tag.children
+		: tag.children.map(renderTag).join('');
+	return `${open}${children}</${tag.tag}>`;
+}
+
+/** Escape double quotes in an attribute value so it can be safely emitted inside `"..."`. */
+function escapeAttr(v: string): string {
+	return v.replace(/"/g, '&quot;');
+}
+
+/**
+ * Inject favicon `<link>` tags into an HTML document string.
+ *
+ * Strips any existing `icon` / `shortcut icon` links (preserving `apple-touch-icon`)
+ * and inserts the new tags before `</head>`. If no `</head>` is present, tags are
+ * appended at the end of the document.
+ */
+export function injectTagsIntoHtml(html: string, tags: HtmlTagDescriptor[]): string {
+	const cleaned = html.replace(INJECT_ICON_LINK_RE, '');
+	const rendered = tags.map(renderTag).join('\n    ');
+	if (cleaned.includes('</head>')) {
+		return cleaned.replace('</head>', `    ${rendered}\n  </head>`);
+	}
+	return `${cleaned}\n${rendered}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { basename, extname, resolve } from 'node:path';
 import type { HtmlTagDescriptor, Plugin } from 'vite';
 
-import { buildFaviconTags, INJECT_ICON_LINK_RE } from './html.ts';
+import { buildFaviconTags, INJECT_ICON_LINK_RE, injectTagsIntoHtml } from './html.ts';
 import type { SizedFileInfo } from './html.ts';
 import { generateSizedPngs, packIco } from './ico.ts';
 import type { GenerateOptions, SizedPng } from './ico.ts';
@@ -124,8 +124,15 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 	const rawIncludeSource = emitOpts?.source ?? false;
 	const rawEmitSizes = emitOpts?.sizes ?? false;
 	const rawInject = emitOpts?.inject ?? false;
+	const rawInjectScan = emitOpts?.injectScan;
 	const resizeOpts = sharpOpts?.resize;
 	const pngOpts = sharpOpts?.png;
+
+	const injectScanPaths: string[] = rawInjectScan == null
+		? []
+		: typeof rawInjectScan === 'string'
+		? [rawInjectScan]
+		: rawInjectScan;
 
 	const sizes = Array.isArray(rawSizes) ? rawSizes : [rawSizes];
 
@@ -156,6 +163,9 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 
 	/** Resolved Vite `base` path, set in `configResolved`. */
 	let resolvedBase = '/';
+
+	/** Resolved Vite project root, set in `configResolved`. */
+	let resolvedRoot = process.cwd();
 
 	// --- emitSizes normalization ---
 	const emitSizesFormat: EmitSizesFormat | false = rawEmitSizes === true
@@ -325,9 +335,27 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 					);
 				}
 
+				if (rawInjectScan !== undefined) {
+					if (
+						!(typeof rawInjectScan === 'string'
+							|| (Array.isArray(rawInjectScan) && rawInjectScan.every((p) => typeof p === 'string')))
+					) {
+						throw new Error('[svg-to-ico] `emit.injectScan` must be a string or array of strings.');
+					}
+					if (injectScanPaths.length === 0) {
+						throw new Error('[svg-to-ico] `emit.injectScan` must contain at least one path.');
+					}
+					if (!injectMode) {
+						throw new Error(
+							'[svg-to-ico] `emit.injectScan` requires `emit.inject` to be set (controls which tags are injected).',
+						);
+					}
+				}
+
 				// Resolve input to absolute path for HMR comparison
 				resolvedInput = resolve(config.root, input);
 				resolvedBase = config.base;
+				resolvedRoot = config.root;
 			},
 		},
 
@@ -578,25 +606,59 @@ export default function svgToIco(opts: PluginOptions): Plugin[] {
 			},
 
 			/**
-			 * Surface a warning when `emit.inject` was configured but
-			 * `transformIndexHtml` was never called during this build cycle. This
-			 * happens with frameworks (SvelteKit, VitePress build, some Astro
-			 * adapters) that render HTML outside Vite's pipeline, causing the
-			 * `<link>` injection to silently no-op while files are still emitted.
+			 * Post-bundle HTML processing. Performs two roles:
+			 *
+			 * 1. **injectScan**: when `emit.injectScan` paths are configured, read
+			 *    each file (relative to project root), strip existing icon
+			 *    `<link>` tags, splice in the configured favicon tag set before
+			 *    `</head>`, and write back. Missing files surface a clear warning.
+			 * 2. **No-op warning**: when `emit.inject` was set but neither
+			 *    `transformIndexHtml` fired nor `injectScan` rewrote a file,
+			 *    warn the user that injection silently produced nothing. This
+			 *    catches frameworks (SvelteKit, VitePress, some Astro adapters)
+			 *    that bypass Vite's HTML pipeline.
 			 *
 			 * Multi-environment Vite builds (SvelteKit drives client + ssr) call
 			 * `closeBundle` per environment; only the client environment ever
-			 * triggers `transformIndexHtml`, so the warning is scoped there to
-			 * avoid duplicate output.
+			 * triggers `transformIndexHtml`, so both the scan and the warning
+			 * are scoped to the client environment to avoid duplicate work and
+			 * duplicate output.
 			 */
-			closeBundle(this: { environment?: { name?: string } }) {
+			async closeBundle(this: { environment?: { name?: string } }) {
 				const envName = this.environment?.name;
 				if (envName && envName !== 'client') return;
-				if (injectMode && !buildTransformIndexHtmlCalled) {
+
+				let scannedAny = false;
+				if (injectMode && injectScanPaths.length > 0) {
+					const tags = faviconTags({ base: resolvedBase });
+					for (const rel of injectScanPaths) {
+						const abs = resolve(resolvedRoot, rel);
+						let original: string;
+						try {
+							original = await readFile(abs, 'utf8');
+						} catch {
+							logger?.warn(
+								`[svg-to-ico] injectScan: "${rel}" — file not found at ${abs}, skipping. `
+									+ `Hint: framework adapters may write HTML after Vite's closeBundle hook. `
+									+ `If so, configure injection at the framework level instead.`,
+							);
+							continue;
+						}
+						const next = injectTagsIntoHtml(original, tags);
+						if (next !== original) {
+							await writeFile(abs, next, 'utf8');
+							scannedAny = true;
+							logger?.info(`[svg-to-ico] injectScan: rewrote ${rel}`);
+						}
+					}
+				}
+
+				if (injectMode && !buildTransformIndexHtmlCalled && !scannedAny) {
 					logger?.warn(
 						`[svg-to-ico] inject: '${injectMode}' was requested but transformIndexHtml was never called during build. `
 							+ `This happens with frameworks (SvelteKit, VitePress build, some Astro adapters) that bypass Vite's HTML pipeline. `
-							+ `Add favicon <link> tags manually to your framework's HTML template or head config — the generated files are still emitted correctly.`,
+							+ `Add favicon <link> tags manually to your framework's HTML template/head config, or set \`emit.injectScan\` to a list of HTML paths to rewrite post-build. `
+							+ `The generated favicon files are still emitted correctly.`,
 					);
 				}
 			},

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,22 @@ export interface EmitOptions {
 	 * @default false
 	 */
 	inject?: boolean | InjectMode;
+	/** Additional HTML files to inject favicon `<link>` tags into after the build
+	 * completes. Paths are resolved relative to the Vite project root.
+	 *
+	 * Use this for frameworks that bypass Vite's `transformIndexHtml` pipeline
+	 * (SvelteKit `build/index.html`, VitePress prerendered pages, etc.). The
+	 * plugin reads each file, strips existing `<link rel="icon">` tags, inserts
+	 * the configured tag set before `</head>`, and writes the file back.
+	 *
+	 * Requires {@link EmitOptions.inject} to also be set (controls *which* tags
+	 * are injected). Files that do not exist are reported via a warning and
+	 * skipped.
+	 *
+	 * @example ['build/index.html', 'build/404.html']  // SvelteKit adapter-static
+	 * @default undefined
+	 */
+	injectScan?: string | string[];
 }
 
 /** Sharp image processing options. */

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { buildFaviconTags, INJECT_ICON_LINK_RE } from '$/html.ts';
+import { buildFaviconTags, INJECT_ICON_LINK_RE, injectTagsIntoHtml, renderTag } from '$/html.ts';
 
 describe('buildFaviconTags', () => {
 	it('minimal mode: returns ICO tag only for non-SVG input', () => {
@@ -115,5 +115,74 @@ describe('INJECT_ICON_LINK_RE', () => {
 	it('does NOT match stylesheet', () => {
 		INJECT_ICON_LINK_RE.lastIndex = 0;
 		expect('<link rel="stylesheet" href="/style.css">').not.toMatch(INJECT_ICON_LINK_RE);
+	});
+});
+
+describe('renderTag', () => {
+	it('renders a void link tag with attributes', () => {
+		expect(renderTag({
+			tag: 'link',
+			attrs: { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+		})).toBe('<link rel="icon" type="image/x-icon" href="/favicon.ico">');
+	});
+
+	it('escapes double quotes in attribute values', () => {
+		expect(renderTag({
+			tag: 'link',
+			attrs: { rel: 'icon', href: '/path"with"quotes.ico' },
+		})).toBe('<link rel="icon" href="/path&quot;with&quot;quotes.ico">');
+	});
+
+	it('skips false/undefined/null attribute values', () => {
+		expect(renderTag({
+			tag: 'link',
+			attrs: { rel: 'icon', href: '/favicon.ico', disabled: false, foo: undefined as any },
+		})).toBe('<link rel="icon" href="/favicon.ico">');
+	});
+
+	it('renders boolean true attribute as bare name', () => {
+		expect(renderTag({
+			tag: 'script',
+			attrs: { async: true, src: '/x.js' },
+			children: '',
+		})).toBe('<script async src="/x.js"></script>');
+	});
+
+	it('renders children for non-void tags', () => {
+		expect(renderTag({
+			tag: 'script',
+			attrs: { type: 'module' },
+			children: 'console.log(1)',
+		})).toBe('<script type="module">console.log(1)</script>');
+	});
+});
+
+describe('injectTagsIntoHtml', () => {
+	const FAVICON_TAG = {
+		tag: 'link',
+		attrs: { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
+	} as const;
+
+	it('inserts tags before </head>', () => {
+		const html = '<html><head><title>x</title></head><body></body></html>';
+		const out = injectTagsIntoHtml(html, [FAVICON_TAG]);
+		expect(out).toContain('<link rel="icon" type="image/x-icon" href="/favicon.ico">');
+		expect(out.indexOf('<link rel="icon"')).toBeLessThan(out.indexOf('</head>'));
+	});
+
+	it('strips existing icon links but preserves apple-touch-icon', () => {
+		const html =
+			'<html><head><link rel="icon" href="/old.ico"><link rel="apple-touch-icon" href="/apple.png"></head><body></body></html>';
+		const out = injectTagsIntoHtml(html, [FAVICON_TAG]);
+		expect(out).not.toContain('/old.ico');
+		expect(out).toContain('apple-touch-icon');
+		expect(out).toContain('/favicon.ico');
+	});
+
+	it('appends tags when no </head> is present', () => {
+		const html = '<div>fragment</div>';
+		const out = injectTagsIntoHtml(html, [FAVICON_TAG]);
+		expect(out).toContain('/favicon.ico');
+		expect(out.startsWith('<div>fragment</div>')).toBe(true);
 	});
 });

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'bun:test';
-import { resolve } from 'node:path';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 import svgToIco from '$/index.ts';
 
@@ -139,27 +141,27 @@ describe('build plugin: inject-no-op warning', () => {
 		return plugins.find((p) => p.name === 'svg-to-ico:build') as any;
 	}
 
-	it('warns when inject is set but transformIndexHtml never fires', () => {
+	it('warns when inject is set but transformIndexHtml never fires', async () => {
 		const { logger, warns } = mockLogger();
 		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: 'minimal' } }, logger);
-		build.closeBundle();
+		await build.closeBundle();
 		expect(warns).toHaveLength(1);
 		expect(warns[0]).toContain("inject: 'minimal' was requested");
 		expect(warns[0]).toContain('transformIndexHtml was never called');
 	});
 
-	it('does not warn when transformIndexHtml fires', () => {
+	it('does not warn when transformIndexHtml fires', async () => {
 		const { logger, warns } = mockLogger();
 		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: 'full' } }, logger);
 		build.transformIndexHtml('<html><head></head><body></body></html>');
-		build.closeBundle();
+		await build.closeBundle();
 		expect(warns).toHaveLength(0);
 	});
 
-	it('does not warn when inject is disabled', () => {
+	it('does not warn when inject is disabled', async () => {
 		const { logger, warns } = mockLogger();
 		const build = getBuildPlugin({ input: FIXTURE, emit: { inject: false } }, logger);
-		build.closeBundle();
+		await build.closeBundle();
 		expect(warns).toHaveLength(0);
 	});
 
@@ -205,5 +207,101 @@ describe('build plugin: inject-no-op warning', () => {
 		build.closeBundle();
 		expect(warns).toHaveLength(1);
 		expect(warns[0]).toContain('transformIndexHtml was never called');
+	});
+});
+
+describe('build plugin: emit.injectScan', () => {
+	function mockLogger() {
+		const warns: string[] = [];
+		const infos: string[] = [];
+		const logger = {
+			info: (msg: string) => infos.push(msg),
+			warn: (msg: string) => warns.push(msg),
+			warnOnce: (msg: string) => warns.push(msg),
+			error: () => {},
+			clearScreen: () => {},
+			hasErrorLogged: () => false,
+			hasWarned: false,
+		};
+		return { logger, warns, infos };
+	}
+
+	async function setupTmp() {
+		const dir = await mkdtemp(join(tmpdir(), 'svg-to-ico-'));
+		return dir;
+	}
+
+	function getBuildPlugin(
+		opts: Parameters<typeof svgToIco>[0],
+		logger: ReturnType<typeof mockLogger>['logger'],
+		root: string,
+	) {
+		const plugins = svgToIco(opts);
+		(plugins[0] as any).configResolved({ root, base: '/', logger });
+		return plugins.find((p) => p.name === 'svg-to-ico:build') as any;
+	}
+
+	it('rewrites HTML files and suppresses the no-op warning', async () => {
+		const root = await setupTmp();
+		const htmlPath = join(root, 'index.html');
+		await writeFile(htmlPath, '<html><head><title>x</title></head><body></body></html>');
+
+		const { logger, warns, infos } = mockLogger();
+		const build = getBuildPlugin(
+			{ input: FIXTURE, emit: { inject: 'minimal', injectScan: 'index.html' } },
+			logger,
+			root,
+		);
+		await build.closeBundle();
+
+		const updated = await readFile(htmlPath, 'utf8');
+		expect(updated).toContain('rel="icon"');
+		expect(updated).toContain('/favicon.ico');
+		expect(warns).toHaveLength(0);
+		expect(infos.some((m) => m.includes('injectScan: rewrote index.html'))).toBe(true);
+	});
+
+	it('accepts an array of paths', async () => {
+		const root = await setupTmp();
+		await writeFile(join(root, 'a.html'), '<head></head>');
+		await writeFile(join(root, 'b.html'), '<head></head>');
+
+		const { logger, infos } = mockLogger();
+		const build = getBuildPlugin(
+			{ input: FIXTURE, emit: { inject: 'minimal', injectScan: ['a.html', 'b.html'] } },
+			logger,
+			root,
+		);
+		await build.closeBundle();
+
+		expect(await readFile(join(root, 'a.html'), 'utf8')).toContain('/favicon.ico');
+		expect(await readFile(join(root, 'b.html'), 'utf8')).toContain('/favicon.ico');
+		expect(infos.filter((m) => m.includes('injectScan: rewrote')).length).toBe(2);
+	});
+
+	it('warns and skips missing files', async () => {
+		const root = await setupTmp();
+		const { logger, warns } = mockLogger();
+		const build = getBuildPlugin(
+			{ input: FIXTURE, emit: { inject: 'minimal', injectScan: 'missing.html' } },
+			logger,
+			root,
+		);
+		await build.closeBundle();
+		expect(warns.some((m) => m.includes('injectScan: "missing.html"'))).toBe(true);
+	});
+
+	it('throws when injectScan is set without inject', () => {
+		expect(() => {
+			const plugins = svgToIco({ input: FIXTURE, emit: { injectScan: 'index.html' } });
+			(plugins[0] as any).configResolved({ root: '/tmp', base: '/', logger: { info: () => {}, warn: () => {} } });
+		}).toThrow('requires `emit.inject` to be set');
+	});
+
+	it('throws on empty array', () => {
+		expect(() => {
+			const plugins = svgToIco({ input: FIXTURE, emit: { inject: 'minimal', injectScan: [] } });
+			(plugins[0] as any).configResolved({ root: '/tmp', base: '/', logger: { info: () => {}, warn: () => {} } });
+		}).toThrow('must contain at least one path');
 	});
 });


### PR DESCRIPTION
**Stacked on #2.** Merge that first; this PR's base will then auto-retarget to `master`.

## Summary

Closes part 2 of #1 — adds opt-in support for frameworks whose HTML lives outside Vite's bundle (SvelteKit static, VitePress, etc).

New option:

```ts
svgToIco({
  input: 'src/icon.svg',
  emit: {
    inject: 'minimal',
    injectScan: ['build/index.html', 'build/404.html'],  // SvelteKit adapter-static
  },
})
```

In `closeBundle` the plugin reads each path (relative to project root), strips existing `<link rel=\"icon\">` tags (preserving `apple-touch-icon`), splices the configured favicon tags in before `</head>`, and writes back.

- Closes #5

## Why explicit paths (not auto-detection)

- Framework adapter output dirs vary: `adapter-static` writes to `build/`, `adapter-node` to `build/client/`, `adapter-cloudflare` differs again; VitePress `outDir` is configurable.
- Hook ordering between our `closeBundle` and the framework adapter's writes is non-deterministic. If the file doesn't exist when we scan, we emit a clear warning explaining the timing caveat — no silent failure.
- Auto-detection would couple us to specific framework versions; explicit paths let users own the contract.

## Changes

- `src/types.ts`: new `EmitOptions.injectScan: string | string[]`.
- `src/html.ts`: factored out `renderTag()` (HtmlTagDescriptor → string with attr escaping) and `injectTagsIntoHtml()` (strip + splice before `</head>`).
- `src/index.ts`: normalize `injectScan` paths; validate in `configResolved` (requires `inject`; non-empty); process in async `closeBundle` — info-log per rewrite, warn on missing files, suppress the no-op warning from #2 when at least one file was rewritten.
- `tests/html.test.ts`: 8 new tests for `renderTag` + `injectTagsIntoHtml`.
- `tests/plugin.test.ts`: 5 new tests covering rewrite happy path, multi-path array, missing file warn, validation errors.
- `CHANGELOG.md`: Unreleased entry.

## Test plan

- [x] `bun test` — 90 pass, 0 fail
- [x] `bun --bun typecheck` — clean
- [ ] Verify against a real SvelteKit `adapter-static` build (reviewer)
- [ ] Verify against a VitePress build (reviewer)

## Known caveats (documented in option JSDoc + warning text)

- Hook ordering: if a framework adapter writes HTML after our `closeBundle` runs, the scan finds nothing. Warning text suggests configuring at the framework level in that case.
- Globs not supported (yet). If demand emerges, can add via `node:fs` glob in a follow-up.