### PR TITLE
feat: vite-svg-to-ico CLI for framework integration

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -2,7 +2,6 @@
 	"lineWidth": 120,
 	"extends": "https://raw.githubusercontent.com/kjanat/kjanat/master/configs/dprint.remote.json",
 	"excludes": [".github/workflows/capture.yml", ".github/actions/capture/action.yml", "**/tests/fixtures"],
-	"exec": { "commands": [{ "command": "bunx sort-package-json --stdin", "fileNames": ["package.json"] }] },
 	"malva": { "useTabs": false },
 	"markup": {
 		"indentWidth": 2,
@@ -11,7 +10,4 @@
 		"formatComments": true,
 		"quotes": "single",
 	},
-	"plugins": [
-		"https://plugins.dprint.dev/exec-0.6.0.json@a054130d458f124f9b5c91484833828950723a5af3f8ff2bd1523bd47b83b364",
-	],
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-bun.lock -diff linguist-generated

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,4 @@ dist
 .nfs*
 
 # End of https://gitignore.kjanat.com/api/node,linux
+*.tmp.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `vite-svg-to-ico` CLI binary. Two subcommands: `generate` (ICO + per-size files from any sharp-supported source image) and `inject` (rewrite `<link rel="icon">` tags into existing HTML files). Built on `@kjanat/dreamcli`. Use as a `"postbuild"` script in `package.json` for frameworks that render HTML outside Vite's pipeline (SvelteKit, VitePress, Astro adapters), where the plugin's `transformIndexHtml` never fires. ([#1](https://github.com/kjanat/vite-svg-to-ico/issues/1))
+- `svg-to-ico` CLI binary (shipped by this package; not tied to Vite). Two
+  subcommands: `generate` (ICO + per-size files from any sharp-supported source
+  image) and `inject` (rewrite `<link rel="icon">` tags into existing HTML files).
+  Built on `@kjanat/dreamcli`. Use as a `"postbuild"` script in `package.json` for
+  frameworks that render HTML outside Vite's pipeline (SvelteKit, VitePress, Astro
+  adapters), where the plugin's `transformIndexHtml` never fires.
+  ([#1](https://github.com/kjanat/vite-svg-to-ico/issues/1))
 - `renderTag` and `injectTagsIntoHtml` helpers in `src/html.ts` (internal), shared between the plugin and CLI.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,92 +7,171 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-05-12
+
 ### Added
 
-- `svg-to-ico` CLI binary (shipped by this package; not tied to Vite). Two
-  subcommands: `generate` (ICO + per-size files from any sharp-supported source
-  image) and `inject` (rewrite `<link rel="icon">` tags into existing HTML files).
-  Built on `@kjanat/dreamcli`. Use as a `"postbuild"` script in `package.json` for
-  frameworks that render HTML outside Vite's pipeline (SvelteKit, VitePress, Astro
-  adapters), where the plugin's `transformIndexHtml` never fires.
-  ([#1](https://github.com/kjanat/vite-svg-to-ico/issues/1))
-- `renderTag` and `injectTagsIntoHtml` helpers in `src/html.ts` (internal), shared between the plugin and CLI.
+- `svg-to-ico` CLI binary (shipped by this package; not tied to Vite).
+  Two subcommands:
+  `generate` (ICO + per-size files from any sharp-supported source image)
+  and `inject` (rewrite `<link rel="icon">` tags into existing HTML files).
+  Built on `@kjanat/dreamcli`.
+  Use as a `"postbuild"` script in `package.json`
+  for frameworks that render HTML outside Vite's pipeline
+  (SvelteKit, VitePress, Astro adapters),
+  where the plugin's `transformIndexHtml` never fires.
+  (https://github.com/kjanat/vite-svg-to-ico/issues/1)
+- `renderTag` and `injectTagsIntoHtml` helpers in `src/html.ts` (internal),
+  shared between the plugin and CLI.
+- `engines: { node: ">=22.18.0" }` field;
+  the CLI relies on modern Node features.
 
 ### Changed
 
-- Package internal import resolution moved from `tsconfig` path aliases to Node-spec `package.json` `imports` field (`#vite-svg-to-ico` for the public entry, `#internals/*` for source-relative imports).
+- Package internal import resolution
+  moved from `tsconfig` path aliases
+  to Node-spec `package.json` `imports` field
+  (`#vite-svg-to-ico` for the public entry,
+  `#internals/*` for source-relative imports).
+- `buildFaviconTags` normalizes `base` (trailing-slash safe)
+  and strips leading slashes from joined segments —
+  `--base /app` and `--base /app/` now yield identical `/app/favicon.ico` hrefs.
+- `injectTagsIntoHtml` matches `</head>` case-insensitively
+  and preserves the original tag casing in output.
+
+### Fixed
+
+- README: dropped the unrunnable `npm i -g …` placeholder;
+  full `npm i -g vite-svg-to-ico` command shown.
+- CLI `generate`: parent directories of nested `--output` paths
+  (e.g. `icons/favicon.ico`) are created before writing
+  instead of failing with `ENOENT`.
+- CLI `inject`: only `ENOENT` is treated as "file not found, skipping";
+  permission and other I/O errors
+  are no longer mislabeled and silently swallowed.
 
 ## [2.2.0] - 2026-05-12
 
 ### Added
 
-- Build-time warning when `emit.inject` is configured but Vite's `transformIndexHtml` is never called (e.g. SvelteKit, VitePress build, some Astro adapters). The plugin now logs a clear message instead of silently producing files with no `<link>` tags injected. Verified end-to-end against a real SvelteKit `adapter-static` build. ([#1](https://github.com/kjanat/vite-svg-to-ico/issues/1))
+- Build-time warning
+  when `emit.inject` is configured
+  but Vite's `transformIndexHtml` is never called
+  (e.g. SvelteKit, VitePress build, some Astro adapters).
+  The plugin now logs a clear message
+  instead of silently producing files with no `<link>` tags injected.
+  Verified end-to-end against a real SvelteKit `adapter-static` build.
+  (https://github.com/kjanat/vite-svg-to-ico/issues/1)
 
 ### Fixed
 
-- Warning is now gated on `this.environment?.name === 'client'`. Multi-environment Vite builds (SvelteKit drives client + ssr) called `closeBundle` per environment, causing the warning to print twice; only the client environment ever triggers `transformIndexHtml`, so the SSR-side duplicate was pure noise.
-- `buildTransformIndexHtmlCalled` flag resets in `buildStart`, fixing stale state across build cycles in watch mode.
+- Warning is now gated on `this.environment?.name === 'client'`.
+  Multi-environment Vite builds (SvelteKit drives client + ssr)
+  called `closeBundle` per environment,
+  causing the warning to print twice;
+  only the client environment ever triggers `transformIndexHtml`,
+  so the SSR-side duplicate was pure noise.
+- `buildTransformIndexHtmlCalled` flag resets in `buildStart`,
+  fixing stale state across build cycles in watch mode.
 
 ## [2.1.0] - 2026-05-12
 
 ### Added
 
-- `autofix.ci` workflow for automatic dprint formatting on push and PRs
-- Vite 8 peer dependency support (`vite: ^6.0.0 || ^7.0.0 || ^8.0.0`); installs no longer rejected on Vite 8 projects
+- `autofix.ci` workflow for automatic dprint formatting on push and PRs.
+- Vite 8 peer dependency support
+  (`vite: ^6.0.0 || ^7.0.0 || ^8.0.0`);
+  installs no longer rejected on Vite 8 projects.
 
 ### Changed
 
-- Publish workflow: `--frozen-lockfile`, strict tag pattern, prerelease `next`/`latest` tag via `actions/github-script`, `bun i -g npm`, rely on `prepublishOnly` for test+typecheck gate
+- Publish workflow:
+  `--frozen-lockfile`, strict tag pattern,
+  prerelease `next`/`latest` tag via `actions/github-script`,
+  `bun i -g npm`,
+  rely on `prepublishOnly` for test+typecheck gate.
 
 ## [2.0.1] - 2026-03-01
 
 ### Fixed
 
-- Injected favicon `<link>` tags now respect Vite's `base` config. Previously, hrefs were always absolute (`/favicon.ico`), breaking deployments on subdirectory paths like GitHub Pages (`base: './'` → `./favicon.ico`).
+- Injected favicon `<link>` tags now respect Vite's `base` config.
+  Previously, hrefs were always absolute (`/favicon.ico`),
+  breaking deployments on subdirectory paths like GitHub Pages
+  (`base: './'` → `./favicon.ico`).
 
 ## [2.0.0] - 2026-02-26
 
 ### Added
 
 - `emit` option object for output control:
-  - `emit.source` — emit the source file alongside the ICO (`boolean | { name?, enabled? }`).
-  - `emit.sizes` — emit individual per-size files (`true`/`'png'`/`'ico'`/`'both'`).
-  - `emit.inject` — auto-inject `<link>` tags into HTML (`true`/`'minimal'`/`'full'`); strips existing `<link rel="icon">` tags while preserving `apple-touch-icon`.
+  - `emit.source` — emit the source file alongside the ICO
+    (`boolean | { name?, enabled? }`).
+  - `emit.sizes` — emit individual per-size files
+    (`true`/`'png'`/`'ico'`/`'both'`).
+  - `emit.inject` — auto-inject `<link>` tags into HTML
+    (`true`/`'minimal'`/`'full'`);
+    strips existing `<link rel="icon">` tags
+    while preserving `apple-touch-icon`.
 - `sharp` option object for image processing control:
   - `sharp.optimize` — toggle max PNG compression.
-  - `sharp.resize` — forward sharp `ResizeOptions` (e.g., `kernel: 'nearest'` for pixel art).
-  - `sharp.png` — forward sharp `PngOptions` (e.g., `palette: true`, custom `compressionLevel`).
+  - `sharp.resize` — forward sharp `ResizeOptions` (e.g., `kernel: 'nearest'`
+    for pixel art).
+  - `sharp.png` — forward sharp `PngOptions` (e.g., `palette: true`, custom
+    `compressionLevel`).
 - `bun` export condition for direct TypeScript source resolution in Bun.
 - Conditional exports (`bun` → `default`) with proper `./package.json` subpath.
 - `dev` option for fine-grained dev-server control (`boolean | DevOptions`):
   - `dev: false` disables the serve plugin entirely (build-only mode).
-  - `dev: { injection: 'shim' }` injects a runtime script that dynamically manages `<link>` tags instead of rewriting HTML via `transformIndexHtml` — useful for backend-rendered HTML or SPA shells.
+  - `dev: { injection: 'shim' }` injects a runtime script
+    that dynamically manages `<link>` tags
+    instead of rewriting HTML via `transformIndexHtml` —
+    useful for backend-rendered HTML or SPA shells.
   - `dev: { hmr: false }` disables favicon hot-reload on source file changes.
-- Non-SVG input support: PNG, JPEG, WebP, AVIF, GIF, and TIFF via sharp format detection.
-- New `src/html.ts` module with `buildFaviconTags()` pure function and `INJECT_ICON_LINK_RE` regex.
-- Exported `generateSizedPngs()` and `packIco()` from `ico.ts` for composable usage.
-- Runtime validation of `emit.sizes`, `emit.inject`, and `dev.injection` string values in `configResolved`.
-- New type exports: `EmitOptions`, `SharpOptions`, `EmitSizesFormat`, `InjectMode`, `DevOptions`, `DevInjection`, `GenerateOptions`.
-- `EMIT_SIZES_FORMATS`, `INJECT_MODES`, and `DEV_INJECTIONS` const arrays exported.
+- Non-SVG input support: PNG, JPEG, WebP, AVIF, GIF, and TIFF via sharp format
+  detection.
+- New `src/html.ts` module with `buildFaviconTags()` pure function and
+  `INJECT_ICON_LINK_RE` regex.
+- Exported `generateSizedPngs()` and `packIco()` from `ico.ts` for composable
+  usage.
+- Runtime validation of `emit.sizes`, `emit.inject`, and `dev.injection`
+  string values in `configResolved`.
+- New type exports: `EmitOptions`, `SharpOptions`, `EmitSizesFormat`,
+  `InjectMode`, `DevOptions`, `DevInjection`, `GenerateOptions`.
+- `EMIT_SIZES_FORMATS`, `INJECT_MODES`, and `DEV_INJECTIONS` const arrays
+  exported.
 - Complete JSDoc/TSDoc coverage across all source files.
-- Comprehensive test suite: 74 tests covering unit, plugin validation, and integration (real Vite builds + dev server).
+- Comprehensive test suite: 74 tests covering unit, plugin validation, and
+  integration (real Vite builds + dev server).
 
 ### Changed
 
-- **BREAKING:** Plugin options restructured from 10 top-level keys to 6 for better DX.
-- `emit.source` serves correct `Content-Type` for non-SVG inputs (was hardcoded to `image/svg+xml`).
-- Serve `transformIndexHtml` returns structured `{ html, tags }` instead of raw string manipulation.
-- `packIco()` signature simplified: accepts `SizedPng[]` instead of separate `Buffer[]` + `number[]`.
-- `generateSizedPngs()` now accepts a `GenerateOptions` object instead of positional args.
-- Validation of option string values now derived from const arrays instead of duplicated sets.
+- **BREAKING:** Plugin options restructured from 10 top-level keys to 6 for
+  better DX.
+- `emit.source` serves correct `Content-Type` for non-SVG inputs (was
+  hardcoded to `image/svg+xml`).
+- Serve `transformIndexHtml` returns structured `{ html, tags }` instead of
+  raw string manipulation.
+- `packIco()` signature simplified: accepts `SizedPng[]` instead of separate
+  `Buffer[]` + `number[]`.
+- `generateSizedPngs()` now accepts a `GenerateOptions` object instead of
+  positional args.
+- Validation of option string values now derived from const arrays instead
+  of duplicated sets.
 
 ### Fixed
 
-- HMR `handleHotUpdate` compared absolute `file` path to possibly-relative `input`; now resolves `input` to absolute via `config.root`.
-- `.jpg` and `.tif` extensions produced invalid MIME types (`image/jpg`, `image/tif`); now normalized to `image/jpeg` and `image/tiff`.
+- HMR `handleHotUpdate`
+  compared absolute `file` path to possibly-relative `input`;
+  now resolves `input` to absolute via `config.root`.
+- `.jpg` and `.tif` extensions produced invalid MIME types
+  (`image/jpg`, `image/tif`);
+  now normalized to `image/jpeg` and `image/tiff`.
 - Empty `sizes: []` now throws instead of producing a degenerate 6-byte ICO.
-- Empty `input: ''` now reports "must be a non-empty string" instead of misleading "unsupported format" error.
-- ICO endpoint fallback now populates per-size cache to avoid redundant `generateSizedPngs` calls.
+- Empty `input: ''` now reports "must be a non-empty string"
+  instead of misleading "unsupported format" error.
+- ICO endpoint fallback now populates per-size cache
+  to avoid redundant `generateSizedPngs` calls.
 
 ## [1.0.0] - 2026-02-26
 
@@ -114,40 +193,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- True HMR favicon swap: source SVG changes update the browser tab icon in-place without a full page reload.
-- Injected client-side script listens for the `svg-to-ico:update` custom event and swaps every `<link rel="…icon…">` href with a cache-busted URL.
-- `transformIndexHtml` hook appends a `?v=` cache-bust param to all icon `<link>` tags on initial page load during dev.
-- `Cache-Control: no-cache` header on the dev-server ICO middleware to prevent stale favicon responses.
+- True HMR favicon swap:
+  source SVG changes update the browser tab icon in-place
+  without a full page reload.
+- Injected client-side script listens for the `svg-to-ico:update` custom event
+  and swaps every `<link rel="…icon…">` href with a cache-busted URL.
+- `transformIndexHtml` hook appends a `?v=` cache-bust param
+  to all icon `<link>` tags on initial page load during dev.
+- `Cache-Control: no-cache` header on the dev-server ICO middleware
+  to prevent stale favicon responses.
 - `postpack` npm script to restore `README.md` after `prepack` formatting.
 - npm version badge in README.
 
 ### Changed
 
-- HMR mechanism replaced: `full-reload` dispatch replaced with a custom Vite HMR event (`svg-to-ico:update`), preserving client-side state across SVG edits.
+- HMR mechanism replaced:
+  `full-reload` dispatch replaced
+  with a custom Vite HMR event (`svg-to-ico:update`),
+  preserving client-side state across SVG edits.
 - README code examples reformatted to match project tab indentation style.
 
 ### Fixed
 
-- Browser could serve a stale cached favicon during dev even after the ICO was regenerated, due to missing cache-control headers and no cache-busting on the `<link>` href.
+- Browser could serve a stale cached favicon during dev
+  even after the ICO was regenerated,
+  due to missing cache-control headers and no cache-busting on the `<link>` href.
 
 ## [0.1.0] - 2026-02-26
 
 ### Added
 
 - SVG-to-ICO conversion using `sharp` for rasterization into PNG-in-ICO format.
-- Configurable icon sizes (integers 1-256, default `[16, 32, 48]`) with IDE-friendly `IconSize` type autocomplete.
-- Optional PNG optimization (compression level 9 + adaptive filtering, enabled by default).
-- Dev server middleware that serves the generated ICO at the configured output path.
+- Configurable icon sizes (integers 1-256, default `[16, 32, 48]`)
+  with IDE-friendly `IconSize` type autocomplete.
+- Optional PNG optimization
+  (compression level 9 + adaptive filtering, enabled by default).
+- Dev server middleware that serves the generated ICO
+  at the configured output path.
 - Auto-regeneration when the source SVG changes during development.
 - Build-time ICO emission as a Rollup asset.
-- `includeSource` option to emit the original SVG alongside the ICO (with optional custom filename).
+- `includeSource` option to emit the original SVG alongside the ICO
+  (with optional custom filename).
 - Input validation for required `input` path and size range constraints.
-- Debug timing instrumentation via `DEBUG=vite-svg-to-ico` environment variable.
-- Three composable sub-plugins (`config`, `serve`, `build`) for clean Vite integration.
+- Debug timing instrumentation
+  via `DEBUG=vite-svg-to-ico` environment variable.
+- Three composable sub-plugins (`config`, `serve`, `build`)
+  for clean Vite integration.
 - Vite 6 and 7 peer dependency compatibility.
-- Full TypeScript type exports (`PluginOptions`, `IconSize`, `IncludeSourceOptions`).
+- Full TypeScript type exports
+  (`PluginOptions`, `IconSize`, `IncludeSourceOptions`).
 
-[Unreleased]: https://github.com/kjanat/vite-svg-to-ico/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/kjanat/vite-svg-to-ico/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/kjanat/vite-svg-to-ico/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/kjanat/vite-svg-to-ico/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/kjanat/vite-svg-to-ico/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/kjanat/vite-svg-to-ico/compare/v2.0.0...v2.0.1
@@ -155,3 +252,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.0]: https://github.com/kjanat/vite-svg-to-ico/compare/v0.2.0...v1.0.0
 [0.2.0]: https://github.com/kjanat/vite-svg-to-ico/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/kjanat/vite-svg-to-ico/releases/tag/v0.1.0
+
+<!-- markdownlint-disable-file no-duplicate-heading -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `vite-svg-to-ico` CLI binary. Two subcommands: `generate` (ICO + per-size files from any sharp-supported source image) and `inject` (rewrite `<link rel="icon">` tags into existing HTML files). Built on `@kjanat/dreamcli`. Use as a `"postbuild"` script in `package.json` for frameworks that render HTML outside Vite's pipeline (SvelteKit, VitePress, Astro adapters), where the plugin's `transformIndexHtml` never fires. ([#1](https://github.com/kjanat/vite-svg-to-ico/issues/1))
+- `renderTag` and `injectTagsIntoHtml` helpers in `src/html.ts` (internal), shared between the plugin and CLI.
+
+### Changed
+
+- Package internal import resolution moved from `tsconfig` path aliases to Node-spec `package.json` `imports` field (`#vite-svg-to-ico` for the public entry, `#internals/*` for source-relative imports).
+
 ## [2.2.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Two options:
 plugin still emits the ICO/SVG files — only the tag injection moves to
 the framework.
 
-**2. Use the `vite-svg-to-ico` CLI as a `postbuild` step.** The CLI
+**2. Use the bundled `svg-to-ico` CLI as a `postbuild` step.** The CLI
 rewrites HTML files on disk after the framework's adapter finishes
 writing them. Useful when you want a single source of truth for the
 icon sizes and don't want to duplicate them in framework config.
@@ -139,20 +139,23 @@ icon sizes and don't want to duplicate them in framework config.
 ```json
 {
 	"scripts": {
-		"build": "vite build && vite-svg-to-ico inject build/index.html build/404.html --sizes 16,32,48 --source favicon.svg"
+		"build": "vite build && svg-to-ico inject build/index.html build/404.html --sizes 16,32,48 --source favicon.svg"
 	}
 }
 ```
 
-The CLI also exposes `generate` for producing the ICO/per-size files
-from any sharp-supported source image — useful in non-Vite pipelines:
+The CLI is **not Vite-specific** — it ships with this package as a
+convenience but works against any HTML and any image source. Install
+the package globally (`bun add -g vite-svg-to-ico`, `npm i -g …`) to
+get the `svg-to-ico` command on your PATH for use in non-Vite
+pipelines, one-off CI scripts, or other framework toolchains:
 
 ```sh
-vite-svg-to-ico generate src/icon.svg --out-dir build --sizes 16,32,48 --emit-source --emit-sizes png
-vite-svg-to-ico inject build/index.html --sizes 16,32,48 --source icon.svg
+svg-to-ico generate src/icon.svg --out-dir build --sizes 16,32,48 --emit-source --emit-sizes png
+svg-to-ico inject build/index.html --sizes 16,32,48 --source icon.svg
 ```
 
-Run `vite-svg-to-ico --help` for the full surface.
+Run `svg-to-ico --help` for the full surface.
 
 ### Override sharp options
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ duplicates. `apple-touch-icon` tags are preserved.
 
 SvelteKit, VitePress, and some Astro adapters render their HTML
 **outside** Vite's pipeline, so `transformIndexHtml` never fires and
-`emit.inject` silently produces no tags. The build plugin detects this
+`emit.inject` produces no tags. The build plugin detects this
 and emits a warning, but the fix lives outside the plugin.
 
 Two options:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,43 @@ When `emit.inject` is enabled, existing `<link rel="icon">` and
 `<link rel="shortcut icon">` tags are stripped from the HTML to prevent
 duplicates. `apple-touch-icon` tags are preserved.
 
+### Framework integration (SvelteKit, VitePress, Astro adapters)
+
+SvelteKit, VitePress, and some Astro adapters render their HTML
+**outside** Vite's pipeline, so `transformIndexHtml` never fires and
+`emit.inject` silently produces no tags. The build plugin detects this
+and emits a warning, but the fix lives outside the plugin.
+
+Two options:
+
+**1. Configure tags at the framework level.** Use SvelteKit's
+`app.html`, VitePress's `head` config, or Astro's `<Head>` slot. The
+plugin still emits the ICO/SVG files — only the tag injection moves to
+the framework.
+
+**2. Use the `vite-svg-to-ico` CLI as a `postbuild` step.** The CLI
+rewrites HTML files on disk after the framework's adapter finishes
+writing them. Useful when you want a single source of truth for the
+icon sizes and don't want to duplicate them in framework config.
+
+```json
+{
+	"scripts": {
+		"build": "vite build && vite-svg-to-ico inject build/index.html build/404.html --sizes 16,32,48 --source favicon.svg"
+	}
+}
+```
+
+The CLI also exposes `generate` for producing the ICO/per-size files
+from any sharp-supported source image — useful in non-Vite pipelines:
+
+```sh
+vite-svg-to-ico generate src/icon.svg --out-dir build --sizes 16,32,48 --emit-source --emit-sizes png
+vite-svg-to-ico inject build/index.html --sizes 16,32,48 --source icon.svg
+```
+
+Run `vite-svg-to-ico --help` for the full surface.
+
 ### Override sharp options
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -256,5 +256,3 @@ Set `DEBUG=vite-svg-to-ico` to enable timing instrumentation.
 ## License
 
 [MIT](https://github.com/kjanat/vite-svg-to-ico/blob/master/LICENSE)
-
-<!--markdownlint-disable-file no-hard-tabs-->

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vite-svg-to-ico
 
-[![NPM Version](https://img.shields.io/npm/v/vite-svg-to-ico?logo=npm&labelColor=CB3837&color=black)](https://www.npmjs.com/package/vite-svg-to-ico)
+[![NPM Version](https://img.shields.io/npm/v/vite-svg-to-ico?logo=npm&labelColor=CB3837&color=black)](https://npm.im/package/vite-svg-to-ico)
 
 Vite plugin that converts an image file into a multi-size `.ico` favicon at
 build time.\
@@ -139,20 +139,20 @@ icon sizes and don't want to duplicate them in framework config.
 ```json
 {
 	"scripts": {
-		"build": "vite build && svg-to-ico inject build/index.html build/404.html --sizes 16,32,48 --source favicon.svg"
+		"build": "vite build && svg-to-ico inject build/index.html build/404.html --sizes 16 --sizes 32 --sizes 48 --source favicon.svg"
 	}
 }
 ```
 
 The CLI is **not Vite-specific** — it ships with this package as a
 convenience but works against any HTML and any image source. Install
-the package globally (`bun add -g vite-svg-to-ico`, `npm i -g vite-svg-to-ico`) to
+the package globally (`bun i -g vite-svg-to-ico`, `npm i -g vite-svg-to-ico`) to
 get the `svg-to-ico` command on your PATH for use in non-Vite
 pipelines, one-off CI scripts, or other framework toolchains:
 
 ```sh
-svg-to-ico generate src/icon.svg --out-dir build --sizes 16,32,48 --emit-source --emit-sizes png
-svg-to-ico inject build/index.html --sizes 16,32,48 --source icon.svg
+svg-to-ico generate src/icon.svg --out-dir build --sizes 16 --sizes 32 --sizes 48 --emit-source --emit-sizes png
+svg-to-ico inject build/index.html --sizes 16 --sizes 32 --sizes 48 --source icon.svg
 ```
 
 Run `svg-to-ico --help` for the full surface.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ icon sizes and don't want to duplicate them in framework config.
 
 The CLI is **not Vite-specific** — it ships with this package as a
 convenience but works against any HTML and any image source. Install
-the package globally (`bun add -g vite-svg-to-ico`, `npm i -g …`) to
+the package globally (`bun add -g vite-svg-to-ico`, `npm i -g vite-svg-to-ico`) to
 get the `svg-to-ico` command on your PATH for use in non-Vite
 pipelines, one-off CI scripts, or other framework toolchains:
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,16 +9,17 @@
       },
       "devDependencies": {
         "@arethetypeswrong/core": "^0.18.2",
-        "@types/bun": "latest",
-        "@typescript/native-preview": "^7.0.0-dev.20260225.1",
-        "dprint": "^0.52.0",
-        "publint": "^0.3.17",
-        "tsdown": "^0.20.3",
-        "typescript": "^5.9.3",
+        "@kjanat/dreamcli": "^2.1.0",
+        "@types/bun": "^1.3.13",
+        "@typescript/native-preview": "^7.0.0-dev.20260512.1",
+        "dprint": "^0.54.0",
+        "publint": "^0.3.20",
+        "tsdown": "^0.22.0",
+        "typescript": "^6.0.3",
         "unplugin-unused": "^0.5.7",
       },
       "peerDependencies": {
-        "vite": "^6.0.0 || ^7.0.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
       },
     },
   },
@@ -27,97 +28,45 @@
 
     "@arethetypeswrong/core": ["@arethetypeswrong/core@0.18.2", "", { "dependencies": { "@andrewbranch/untar.js": "^1.0.3", "@loaderkit/resolve": "^1.0.2", "cjs-module-lexer": "^1.2.3", "fflate": "^0.8.2", "lru-cache": "^11.0.1", "semver": "^7.5.4", "typescript": "5.6.1-rc", "validate-npm-package-name": "^5.0.0" } }, "sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg=="],
 
-    "@babel/generator": ["@babel/generator@8.0.0-rc.1", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.1", "@babel/types": "^8.0.0-rc.1", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-3ypWOOiC4AYHKr8vYRVtWtWmyvcoItHtVqF8paFax+ydpmUdPsJpLBkBBs5ItmhdrwC3a0ZSqqFAdzls4ODP3w=="],
+    "@babel/generator": ["@babel/generator@8.0.0-rc.4", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.4", "@babel/types": "^8.0.0-rc.4", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-YZ+FuIgkj7KrIb2a2X1XiY0QYgDxAbVbYP64SjwJzOK3euCsUerzenh2oqdsmKuPSlhzmFOOklnxzHAzXagvpw=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.2", "", {}, "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.5", "", {}, "sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.1", "", {}, "sha512-I4YnARytXC2RzkLNVnf5qFNFMzp679qZpmtw/V3Jt2uGnWiIxyJtaukjG7R8pSx8nG2NamICpGfljQsogj+FbQ=="],
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.4", "", {}, "sha512-HTD3bskipk5MSm08twTW6832jzIXUhxMddy4NPPzIMuyMEsrs0ZgwAaMj5ubB5+6hMlUjDu17vNconEmwsmpYg=="],
 
-    "@babel/parser": ["@babel/parser@8.0.0-rc.1", "", { "dependencies": { "@babel/types": "^8.0.0-rc.1" }, "bin": "./bin/babel-parser.js" }, "sha512-6HyyU5l1yK/7h9Ki52i5h6mDAx4qJdiLQO4FdCyJNoB/gy3T3GGJdhQzzbZgvgZCugYBvwtQiWRt94QKedHnkA=="],
+    "@babel/parser": ["@babel/parser@8.0.0-rc.4", "", { "dependencies": { "@babel/types": "^8.0.0-rc.4" }, "bin": "./bin/babel-parser.js" }, "sha512-0S/1yefMa15N4i2v3t8Fw9pgMHhf2gF6Lc1UEXI96Ls6FNAjqvHHZouZ2ZS/deqLhbMFtmfVeFac6iTsvFbLwA=="],
 
-    "@babel/types": ["@babel/types@8.0.0-rc.1", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.1", "@babel/helper-validator-identifier": "^8.0.0-rc.1" } }, "sha512-ubmJ6TShyaD69VE9DQrlXcdkvJbmwWPB8qYj0H2kaJi29O7vJT9ajSdBd2W8CG34pwL9pYA74fi7RHC1qbLoVQ=="],
+    "@babel/types": ["@babel/types@8.0.0-rc.5", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.5", "@babel/helper-validator-identifier": "^8.0.0-rc.5" } }, "sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA=="],
 
     "@braidai/lang": ["@braidai/lang@1.1.2", "", {}, "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA=="],
 
-    "@dprint/darwin-arm64": ["@dprint/darwin-arm64@0.52.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-HHpmHCeFw1V9qUU0pJrz7LihrMgQJ5DOejfI3GRCJOd2ue3Api3/ZrzNSIqUbnx/j0RT5c7zxZR5aTE0RHwRFQ=="],
+    "@dprint/darwin-arm64": ["@dprint/darwin-arm64@0.54.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yqRI4enH+BDp+4+ZsPVdZM5h873JK1lN7li9l9A5u4C4cvh1oEsiBWAzEPccRkJ2ctF8LgaizBSxO38sqEVYbw=="],
 
-    "@dprint/darwin-x64": ["@dprint/darwin-x64@0.52.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZuoYH/hyzFhwwFUmykkm1QvLk9u7zxpKL6M8r1fY+lINucujIoGZxW1PjRbbIXaST6nDLbQB21P7LyNncAByOg=="],
+    "@dprint/darwin-x64": ["@dprint/darwin-x64@0.54.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-W9BARpgHypcQwatg5mnHaCpX6pLX5dBxxiv+tZKruhOmq8MKYOrAYDXlceMuHSowmWREfUF5yL4SRgXDGI6WQw=="],
 
-    "@dprint/linux-arm64-glibc": ["@dprint/linux-arm64-glibc@0.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-waghQcB32CLMuCxnVRQktc7U1S2qsL4spUmvCMyu4ufhZqXf4rQn07L1NcSmQOap40q9Db8ZBmLHfHm1Kab6uA=="],
+    "@dprint/linux-arm64-glibc": ["@dprint/linux-arm64-glibc@0.54.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-VhM7p70VFuNqxZMdiv1e+nMboPj/hMFlTIBWrRaX7+6VThs9mJr9+94wrUeXgfnfsyaEKSbRFa/dru1PINoSNw=="],
 
-    "@dprint/linux-arm64-musl": ["@dprint/linux-arm64-musl@0.52.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8ml2DmF8i7eEou1G5nqgMMhRir89Fsd9cMLZRPZN/FSw6Nc3vAhk2MqZIrYk2DGfoWts7jis6XvEu3/TwMP8fw=="],
+    "@dprint/linux-arm64-musl": ["@dprint/linux-arm64-musl@0.54.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-QS1A74Lv60/L9oemHCzbHgOLbV2smSJG5IxS5fjf8ZWetyUt918WDzIHBilz/+uiB+OlW2UVTsm952UG0YOrLw=="],
 
-    "@dprint/linux-loong64-glibc": ["@dprint/linux-loong64-glibc@0.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-tKj7Bwtcf/zNa1onoshYfQ8CaYz0N6BRYKsovop1H1d2dsRBYAKkR/FvTaPRJp1+Sx7Lc0RjRllFezkhLMRxPw=="],
+    "@dprint/linux-loong64-glibc": ["@dprint/linux-loong64-glibc@0.54.0", "", { "os": "linux", "cpu": "none" }, "sha512-8Myka2/0KbhuZnEKL6jagPXTgDKVpd/tfXDRa0oibUBgaqOSku6iRMzHGa/PhqHL+s14Gcp+/cIHz0zU3Tkgug=="],
 
-    "@dprint/linux-loong64-musl": ["@dprint/linux-loong64-musl@0.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-8X+ICN/Pc4B+Zog2UXNDJph5uKLf0VVUItYEQbdbwqsWGzPa27Kqri5ainlFzaDs5TFkJHQKQlphg+TLyxBQ7A=="],
+    "@dprint/linux-loong64-musl": ["@dprint/linux-loong64-musl@0.54.0", "", { "os": "linux", "cpu": "none" }, "sha512-/AN3xCuMhC4PK7Pbj7/4zBuhFGr4m0OHV/5uGTfzpkKX/3+AXoyKl7PbT2VlNMGXAK0kuRThfjtx23gIwlWk7Q=="],
 
-    "@dprint/linux-riscv64-glibc": ["@dprint/linux-riscv64-glibc@0.52.0", "", { "os": "linux", "cpu": "none" }, "sha512-uQb2VqSnznfZHhrAKLxpjXMc7/c3AYepllVUhcGCdrTVp1fb7inHEilT2wSXUjOipBbfPG33cZWRzAgc5/Effg=="],
+    "@dprint/linux-riscv64-glibc": ["@dprint/linux-riscv64-glibc@0.54.0", "", { "os": "linux", "cpu": "none" }, "sha512-Aw2vXzzwFDpPbXh6ajsSabVCkCc66C3hCyMKprR/IxYvFtjYX80nh1ox0c7iaw6c4HacHMRLGw7FUSXvomPaEQ=="],
 
-    "@dprint/linux-x64-glibc": ["@dprint/linux-x64-glibc@0.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Yh3fZYUcHmII+swTUh0qgf0lEPrz4+7v3tq+vqXR8/xa3Sx8QH5MQJsJDw8Ll1mmKX5HrkBNxA5rC1lIDuFn9g=="],
+    "@dprint/linux-x64-glibc": ["@dprint/linux-x64-glibc@0.54.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zZqj3wQELOX8n6QfT2uuWoMf64Wv0lMXNyam3btm+PKkg0P6a54TPL09Bs9XsViOdxgTcamsiQ7HlErt/LEjIA=="],
 
-    "@dprint/linux-x64-musl": ["@dprint/linux-x64-musl@0.52.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zdcgL6+PRjyZ4HVll9DuIn2ZnnxKuU0cwXtpfUZNdy+xRh1+OedUY5aZQRDN4163vkLxV9znXQT/TS0+giph1g=="],
+    "@dprint/linux-x64-musl": ["@dprint/linux-x64-musl@0.54.0", "", { "os": "linux", "cpu": "x64" }, "sha512-it6Qdt06dyW2adbAXpOCb7/KQLxlm4i1UphUAWqWsZk4t3EYetyAza9J0g3Vu9itIWSEIo9MnccgANckQJ6+qw=="],
 
-    "@dprint/win32-arm64": ["@dprint/win32-arm64@0.52.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-rQGhSbl2pcnU4Tl3xXJSPRi1smfIIf7XhVwzNOG7vcSExfcK8yYrrCS3z4VImYKqhI1kvv6gSfnIligtoyaX/g=="],
+    "@dprint/win32-arm64": ["@dprint/win32-arm64@0.54.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-F5kjV/6I9YtNOTDWHUpTqM2HHHS510BPL7z4NJuU0nDnaVeks7GwNEltGr56CcsG8XQYhkiAsqZytPu6AhA2hQ=="],
 
-    "@dprint/win32-x64": ["@dprint/win32-x64@0.52.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Bi4kW6z9eVtRdNSztSvjjYET4SQzX/OYqsexVyppxv24m5RNOG1h+c9F5MFJpYy9LqQBAKHOQfkzQwPrdgNOXQ=="],
+    "@dprint/win32-x64": ["@dprint/win32-x64@0.54.0", "", { "os": "win32", "cpu": "x64" }, "sha512-AAr2ye/DtgYXDplRoPS+5U++x7T6W4a3I9FvTFWFxziFmUptvAg5G2c4FcXoAduSruhYZJvjDZrLseR2c3IwXg=="],
 
-    "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
-
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
-
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
-
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
-
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
-
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
-
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
-
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
-
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
-
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
-
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
-
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
-
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
-
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
-
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
-
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
-
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
-
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
-
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
-
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
-
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
-
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
-
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
-
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
-
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
-
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
-
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
@@ -179,97 +128,53 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@kjanat/dreamcli": ["@kjanat/dreamcli@2.1.0", "", {}, "sha512-dcE11SlCidTKy3RcDlfBEGgA2Wfq3P0WQ7srW4ikk0vYm/Kb6PzFHzUHRKCwpfQXuQkpcQzyCML9v6K+0PtWuQ=="],
+
     "@loaderkit/resolve": ["@loaderkit/resolve@1.0.4", "", { "dependencies": { "@braidai/lang": "^1.0.0" } }, "sha512-rJzYKVcV4dxJv+vW6jlvagF8zvGxHJ2+HTr1e2qOejfmGhAApgJHl8Aog4mMszxceTRiKTTbnpgmTO1bEZHV/A=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.112.0", "", {}, "sha512-m6RebKHIRsax2iCwVpYW2ErQwa4ywHJrE4sCK3/8JK8ZZAWOKXaRJFl/uP51gaVyyXlaS4+chU1nSCdzYf6QqQ=="],
+    "@oxc-project/types": ["@oxc-project/types@0.129.0", "", {}, "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg=="],
 
     "@publint/pack": ["@publint/pack@0.1.4", "", {}, "sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.3", "", { "os": "android", "cpu": "arm64" }, "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JWWLzvcmc/3pe7qdJqPpuPk91SoE/N+f3PcWx/6ZwuyDVyungAEJPvKm/eEldiDdwTmaEzWfIR+HORxYWrCi1A=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-MTakBxfx3tde5WSmbHxuqlDsIW0EzQym+PJYGF4P6lG2NmKzi128OGynoFUqoD5ryCySEY85dug4v+LWGBElIw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jje3oopyOLs7IwfvXoS6Lxnmie5JJO7vW29fdGFu5YGY1EDbVDhD+P9vDihqS5X6fFiqL3ZQZCMBg6jyHkSVww=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.3", "", { "os": "linux", "cpu": "arm" }, "sha512-A0n8P3hdLAaqzSFrQoA42p23ZKBYQOw+8EH5r15Sa9X1kD9/JXe0YT2gph2QTWvdr0CVK2BOXiK6ENfy6DXOag=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0", "", { "os": "linux", "cpu": "arm" }, "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-kWXkoxxarYISBJ4bLNf5vFkEbb4JvccOwxWDxuK9yee8lg5XA7OpvlTptfRuwEvYcOZf+7VS69Uenpmpyo5Bjw=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z03/wrqau9Bicfgb3Dbs6SYTHliELk2PM2LpG2nFd+cGupTMF5kanLEcj2vuuJLLhptNyS61rtk7SOZ+lPsTUA=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.3", "", { "os": "linux", "cpu": "x64" }, "sha512-iSXXZsQp08CSilff/DCTFZHSVEpEwdicV3W8idHyrByrcsRDVh9sGC3sev6d8BygSGj3vt8GvUKBPCoyMA4tgQ=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.3", "", { "os": "linux", "cpu": "x64" }, "sha512-qaj+MFudtdCv9xZo9znFvkgoajLdc+vwf0Kz5N44g+LU5XMe+IsACgn3UG7uTRlCCvhMAGXm1XlpEA5bZBrOcw=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.3", "", { "os": "none", "cpu": "arm64" }, "sha512-U662UnMETyjT65gFmG9ma+XziENrs7BBnENi/27swZPYagubfHRirXHG2oMl+pEax2WvO7Kb9gHZmMakpYqBHQ=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.3", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-gekrQ3Q2HiC1T5njGyuUJoGpK/l6B/TNXKed3fZXNf9YRTJn3L5MOZsFBn4bN2+UX+8+7hgdlTcEsexX988G4g=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-85y5JifyMgs8m5K2XzR/VDsapKbiFiohl7s5lEj7nmNGO0pkTXE7q6TQScei96BNAsoK7JC3pA7ukA8WRHVJpg=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0", "", { "os": "none", "cpu": "arm64" }, "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.3", "", { "os": "win32", "cpu": "x64" }, "sha512-a4VUQZH7LxGbUJ3qJ/TzQG8HxdHvf+jOnqf7B7oFx1TEBm+j2KNL2zr5SQ7wHkNAcaPevF6gf9tQnVBnC4mD+A=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0", "", { "os": "win32", "cpu": "x64" }, "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
-
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
-
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
-
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
-
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
-
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
-
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
-
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
-
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
-
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
-
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
-
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
-
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
-
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
-
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
-
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
-
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
-
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
-
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
-
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
-
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
-
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
-
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
-
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0", "", {}, "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -277,21 +182,21 @@
 
     "@types/node": ["@types/node@25.3.1", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260225.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260225.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260225.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260225.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260225.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260225.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260225.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260225.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-mUf1aON+eZLupLorX4214n4W6uWIz/lvNv81ErzjJylD/GyJPEJkvDLmgIK3bbvLpMwTRWdVJLhpLCah5Qe8iA=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260512.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260512.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260512.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260512.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260512.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260512.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260512.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260512.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-KIzYPGuxZnyiiYkYrozDT94Af2nwbdLXoY1cgGY66RRa9HSEw13RH9WHg8wA8fZhT4wYzF5uF7WY3hz0QhaxGg=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260225.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3qSsqv7FmM4z09wEpEXdhmgMfiJF/OMOZa41AdgMsXTTRpX2/38hDg2KGhi3fc24M2T3MnLPLTqw6HyTOBaV1Q=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260512.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-l9AJi/TIVMPx5R1c7fxZCSA7eUaHeA0C9Mxdxx/oQJo1K/GtbI3mzYe/SiKNltko1KSdKUmWVhPwxTOS289REg=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260225.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-F8ZCCX2UESHcbxvnkd1Dn5PTnOOgpGddFHYgn4usyWRMzNZLPP+YjyGALZe9zdR/D8L0uraND0Haok+TPq8xYg=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260512.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-oABZLQrfB8JN2Ct2CiLK5PyE28Em3sIJlZsAMD45/A2ymtIaa5826dwv8vapE5Wjp54ao0LXxCSuKFm1A8zzCQ=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260225.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Iu5rnCmqwGIMUu//BXkl9VQaxAAsqVvFhU4mJoNexNkMxPqVcu9quqYAouY7tN/95WcKzUsPpyRfkThdbNFO/g=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260512.1", "", { "os": "linux", "cpu": "arm" }, "sha512-0Hs1Gqa/t9cthoPdqHud1pFGUr9DgJivBTjwquTUh8jt/6PI2bQxoMNZLiN/bhqeDFDTzdxoMBfCaytsTMcXqw=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260225.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Up8Z/QNcwce5C4rWnbLNW5w7lRARdyKZcNbB1NMnaswaGOBdeDmdP0wbVsOgJMoDp6vnun+EkvrSft8hWLLhIg=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260512.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-xvbwzpTe+5N6bnBI/t9n4zsGzXxz3V6rVbvDUoJmRLfav5fz+ck0QDkGQGUPrQEEIp0KEzQvx7c+AEZnzdvTQA=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260225.1", "", { "os": "linux", "cpu": "x64" }, "sha512-WWjIfHCWlcriempYYc/sPJ3HFt6znNZKp60nvDNih0+wmxNqEfT5Yzu5zAY0awIe7XLelFSY+bolkpzMYVWEIQ=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260512.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qr5h6FPo74bN/U+EwRuayBhUbxaji8xzFbIbhMOA2oYSc/qozp5ia2g1+9xGw67MXxPPw/IPT+UGvrNK7K1NeQ=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260225.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lmfQO+HdmPMk0dtPoNo8dZereTUYNQuapsAI7nFHCP8F25I8eGKKXY2nD1R8W1hp/LmVtske1pqKFNN6IOCt5g=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260512.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-meNWxhNEfaqos2U0JXvfxWvy4JWrKE9fZepCndDZi+t04X+AIiLYp5s6crWnKP67nzVAzMNgTAc8mu8CnGM+/A=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260225.1", "", { "os": "win32", "cpu": "x64" }, "sha512-e4eJyzR9ne0XreqYgQNqfX7SNuaePxggnUtVrLERgBv25QKwdQl72GnSXDhdxZHzrb97YwumiXWMQQJj9h8NCg=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260512.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Hp6vBnxJSKEEAVWgIoWMmfqkZXCdkhm6XTivrwgRzBwWfiTVe2ZyZ7byWegIKeNnBbffg/K2KvoM8JAHl059GQ=="],
 
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
@@ -299,23 +204,21 @@
 
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+    "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
 
-    "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "dprint": ["dprint@0.52.0", "", { "optionalDependencies": { "@dprint/darwin-arm64": "0.52.0", "@dprint/darwin-x64": "0.52.0", "@dprint/linux-arm64-glibc": "0.52.0", "@dprint/linux-arm64-musl": "0.52.0", "@dprint/linux-loong64-glibc": "0.52.0", "@dprint/linux-loong64-musl": "0.52.0", "@dprint/linux-riscv64-glibc": "0.52.0", "@dprint/linux-x64-glibc": "0.52.0", "@dprint/linux-x64-musl": "0.52.0", "@dprint/win32-arm64": "0.52.0", "@dprint/win32-x64": "0.52.0" }, "bin": { "dprint": "bin.js" } }, "sha512-qXf3B6/G4E6SJKngfo7a0z1ja21o/JJ55cF8xyhyIqvJGrpJ96vhXLr37RrbWBWIj8eV+hquBkCAV6jCwenQYA=="],
+    "dprint": ["dprint@0.54.0", "", { "optionalDependencies": { "@dprint/darwin-arm64": "0.54.0", "@dprint/darwin-x64": "0.54.0", "@dprint/linux-arm64-glibc": "0.54.0", "@dprint/linux-arm64-musl": "0.54.0", "@dprint/linux-loong64-glibc": "0.54.0", "@dprint/linux-loong64-musl": "0.54.0", "@dprint/linux-riscv64-glibc": "0.54.0", "@dprint/linux-x64-glibc": "0.54.0", "@dprint/linux-x64-musl": "0.54.0", "@dprint/win32-arm64": "0.54.0", "@dprint/win32-x64": "0.54.0" }, "bin": { "dprint": "bin.cjs" } }, "sha512-sIy25poR2gRP/tWPTgP0MPeJoJcpv0xzYDcsboapvthbEt1Qw3Al252CA0xFyIh2cYEGGKyBJtKokryv4ERlJw=="],
 
-    "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
+    "dts-resolver": ["dts-resolver@3.0.0", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
-
-    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -327,15 +230,39 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+    "get-tsconfig": ["get-tsconfig@5.0.0-beta.5", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ=="],
 
-    "hookable": ["hookable@6.0.1", "", {}, "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw=="],
+    "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
-    "import-without-cache": ["import-without-cache@0.2.5", "", {}, "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A=="],
+    "import-without-cache": ["import-without-cache@0.4.0", "", {}, "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
@@ -351,21 +278,19 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
-    "publint": ["publint@0.3.17", "", { "dependencies": { "@publint/pack": "^0.1.3", "package-manager-detector": "^1.6.0", "picocolors": "^1.1.1", "sade": "^1.8.1" }, "bin": { "publint": "src/cli.js" } }, "sha512-Q3NLegA9XM6usW+dYQRG1g9uEHiYUzcCVBJDJ7yMcWRqVU9LYZUWdqbwMZfmTCFC5PZLQpLAmhvRcQRl3exqkw=="],
+    "publint": ["publint@0.3.20", "", { "dependencies": { "@publint/pack": "^0.1.4", "package-manager-detector": "^1.6.0", "picocolors": "^1.1.1", "sade": "^1.8.1" }, "bin": { "publint": "src/cli.js" } }, "sha512-UWqFYP7VBVCe9l/leEEGJrDs6Am4K4KapLmLi5qbt+9fA+Ny38ghdW+bw1nYfVqCK8/3kgsxjjhFjTYqYYRpyw=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.3", "", { "dependencies": { "@oxc-project/types": "=0.112.0", "@rolldown/pluginutils": "1.0.0-rc.3" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.3", "@rolldown/binding-darwin-arm64": "1.0.0-rc.3", "@rolldown/binding-darwin-x64": "1.0.0-rc.3", "@rolldown/binding-freebsd-x64": "1.0.0-rc.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.3", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.3", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.3", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.3", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.3", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.3", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.3", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.3", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.3" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-Po/YZECDOqVXjIXrtC5h++a5NLvKAQNrd9ggrIG3sbDfGO5BqTUsrI6l8zdniKRp3r5Tp/2JTrXqx4GIguFCMw=="],
+    "rolldown": ["rolldown@1.0.0", "", { "dependencies": { "@oxc-project/types": "=0.129.0", "@rolldown/pluginutils": "1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0", "@rolldown/binding-darwin-arm64": "1.0.0", "@rolldown/binding-darwin-x64": "1.0.0", "@rolldown/binding-freebsd-x64": "1.0.0", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0", "@rolldown/binding-linux-arm64-gnu": "1.0.0", "@rolldown/binding-linux-arm64-musl": "1.0.0", "@rolldown/binding-linux-ppc64-gnu": "1.0.0", "@rolldown/binding-linux-s390x-gnu": "1.0.0", "@rolldown/binding-linux-x64-gnu": "1.0.0", "@rolldown/binding-linux-x64-musl": "1.0.0", "@rolldown/binding-openharmony-arm64": "1.0.0", "@rolldown/binding-wasm32-wasi": "1.0.0", "@rolldown/binding-win32-arm64-msvc": "1.0.0", "@rolldown/binding-win32-x64-msvc": "1.0.0" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA=="],
 
-    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.22.1", "", { "dependencies": { "@babel/generator": "8.0.0-rc.1", "@babel/helper-validator-identifier": "8.0.0-rc.1", "@babel/parser": "8.0.0-rc.1", "@babel/types": "8.0.0-rc.1", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.1", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20250601.1", "rolldown": "^1.0.0-rc.3", "typescript": "^5.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-5E0AiM5RSQhU6cjtkDFWH6laW4IrMu0j1Mo8x04Xo1ALHmaRMs9/7zej7P3RrryVHW/DdZAp85MA7Be55p0iUw=="],
-
-    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.25.0", "", { "dependencies": { "@babel/generator": "8.0.0-rc.4", "@babel/helper-validator-identifier": "8.0.0-rc.4", "@babel/parser": "8.0.0-rc.4", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0", "typescript": "^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-GE3uDZgUuA9l6g+1u928TRmadd5IVhaWiwpWast2kCyLv9tYJJCC6E5HHkV0HGmwC5ZL73xh12/PRZI+KZ2vdQ=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
@@ -375,17 +300,17 @@
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
-    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+    "tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
-    "tsdown": ["tsdown@0.20.3", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^6.7.14", "defu": "^6.1.4", "empathic": "^2.0.0", "hookable": "^6.0.1", "import-without-cache": "^0.2.5", "obug": "^2.1.1", "picomatch": "^4.0.3", "rolldown": "1.0.0-rc.3", "rolldown-plugin-dts": "^0.22.1", "semver": "^7.7.3", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tree-kill": "^1.2.2", "unconfig-core": "^7.4.2", "unrun": "^0.2.27" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@vitejs/devtools": "*", "publint": "^0.3.0", "typescript": "^5.0.0", "unplugin-lightningcss": "^0.4.0", "unplugin-unused": "^0.5.0" }, "optionalPeers": ["@arethetypeswrong/core", "@vitejs/devtools", "publint", "typescript", "unplugin-lightningcss", "unplugin-unused"], "bin": { "tsdown": "dist/run.mjs" } }, "sha512-qWOUXSbe4jN8JZEgrkc/uhJpC8VN2QpNu3eZkBWwNuTEjc/Ik1kcc54ycfcQ5QPRHeu9OQXaLfCI3o7pEJgB2w=="],
+    "tsdown": ["tsdown@0.22.0", "", { "dependencies": { "ansis": "^4.2.0", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.0", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.1", "picomatch": "^4.0.4", "rolldown": "^1.0.0", "rolldown-plugin-dts": "^0.25.0", "semver": "^7.7.4", "tinyexec": "^1.1.2", "tinyglobby": "^0.2.16", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.0", "@tsdown/exe": "0.22.0", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-FgW0hHb27nGQA/+F3d5+U9wKXkfilk9DVkc5+7x/ZqF03g+Hoz/eeApT32jqxATt9eRoR+1jxk7MUMON+O4CXw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
@@ -395,14 +320,26 @@
 
     "unplugin-unused": ["unplugin-unused@0.5.7", "", { "dependencies": { "empathic": "^2.0.0", "escape-string-regexp": "^5.0.0", "js-tokens": "^10.0.0", "unplugin": "^3.0.0" } }, "sha512-quvqrHs6mPhk1hjbGwMoypXfagveue+/22dtgDrEzc2K9485ZAsnVfq7iYIgv7FwooiRa6+HDaLWgK2IavN+2g=="],
 
-    "unrun": ["unrun@0.2.27", "", { "dependencies": { "rolldown": "1.0.0-rc.3" }, "peerDependencies": { "synckit": "^0.11.11" }, "optionalPeers": ["synckit"], "bin": { "unrun": "dist/cli.mjs" } }, "sha512-Mmur1UJpIbfxasLOhPRvox/QS4xBiDii71hMP7smfRthGcwFL2OAmYRgduLANOAU4LUkvVamuP+02U+c90jlrw=="],
-
     "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
 
-    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+    "vite": ["vite@8.0.12", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
+
+    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.5", "", {}, "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "ast-kit/@babel/parser": ["@babel/parser@8.0.0-rc.1", "", { "dependencies": { "@babel/types": "^8.0.0-rc.1" }, "bin": "./bin/babel-parser.js" }, "sha512-6HyyU5l1yK/7h9Ki52i5h6mDAx4qJdiLQO4FdCyJNoB/gy3T3GGJdhQzzbZgvgZCugYBvwtQiWRt94QKedHnkA=="],
+
+    "unplugin/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.1", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.1", "@babel/helper-validator-identifier": "^8.0.0-rc.1" } }, "sha512-ubmJ6TShyaD69VE9DQrlXcdkvJbmwWPB8qYj0H2kaJi29O7vJT9ajSdBd2W8CG34pwL9pYA74fi7RHC1qbLoVQ=="],
+
+    "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.2", "", {}, "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ=="],
+
+    "ast-kit/@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.1", "", {}, "sha512-I4YnARytXC2RzkLNVnf5qFNFMzp679qZpmtw/V3Jt2uGnWiIxyJtaukjG7R8pSx8nG2NamICpGfljQsogj+FbQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
 		"tag": "latest"
 	},
 	"bin": {
-		"vite-svg-to-ico": "./dist/cli.mjs"
+		"svg-to-ico": "./dist/cli.mjs"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vite-svg-to-ico",
 	"version": "2.2.0",
-	"description": "A Vite plugin that converts SVG files to ICO format during the build process.",
+	"description": "Vite plugin that converts SVG to ICO during site build.",
 	"keywords": [
 		"vite-plugin",
 		"vite",
@@ -24,6 +24,10 @@
 		},
 		"./package.json": "./package.json"
 	},
+	"imports": {
+		"#vite-svg-to-ico": "./src/index.ts",
+		"#internals/*": "./src/*"
+	},
 	"files": [
 		"dist",
 		"src"
@@ -41,16 +45,17 @@
 		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
+		"@kjanat/dreamcli": "^2.1.0",
 		"sharp": "^0.34.5"
 	},
 	"devDependencies": {
 		"@arethetypeswrong/core": "^0.18.2",
-		"@types/bun": "latest",
-		"@typescript/native-preview": "^7.0.0-dev.20260225.1",
-		"dprint": "^0.52.0",
-		"publint": "^0.3.17",
-		"tsdown": "^0.20.3",
-		"typescript": "^5.9.3",
+		"@types/bun": "^1.3.13",
+		"@typescript/native-preview": "^7.0.0-dev.20260512.1",
+		"dprint": "^0.54.0",
+		"publint": "^0.3.20",
+		"tsdown": "^0.22.0",
+		"typescript": "^6.0.3",
 		"unplugin-unused": "^0.5.7"
 	},
 	"peerDependencies": {
@@ -62,5 +67,8 @@
 		"provenance": true,
 		"registry": "https://registry.npmjs.org/",
 		"tag": "latest"
+	},
+	"bin": {
+		"vite-svg-to-ico": "./dist/cli.mjs"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-svg-to-ico",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "Vite plugin that converts SVG to ICO during site build.",
 	"keywords": [
 		"vite-plugin",
@@ -61,6 +61,7 @@
 	"peerDependencies": {
 		"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
 	},
+	"engines": { "node": ">=22.18.0" },
 	"packageManager": "bun@1.3.13",
 	"publishConfig": {
 		"access": "public",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"build": "tsdown",
 		"dev": "tsdown --watch",
 		"fmt": "dprint fmt",
-		"prepack": "bun --bun bd -l error && dprint fmt README.md >/dev/null",
+		"prepack": "bun --bun bd -l error && bunx prettier -w README.md >/dev/null",
 		"postpack": "git restore README.md >/dev/null",
 		"prepublishOnly": "bun test && bun --bun typecheck",
 		"tar": "bun pm pack --quiet | awk 'NF{line=$0} END{print line}'",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,6 +76,14 @@ const pathArg = () => arg.custom<string>(toAbsolutePath);
 /** Reusable absolute-path flag: parsing happens at the schema layer. */
 const pathFlag = () => flag.custom<string>(toAbsolutePath);
 
+/**
+ * `generate` subcommand: rasterize a source image into a multi-size ICO favicon.
+ * Optionally also emits per-size PNG/ICO files and a copy of the source.
+ *
+ * Exported so consumers can compose it into their own `@kjanat/dreamcli` CLI
+ * or unit-test it directly via `runCommand(generate, [...])` from
+ * `@kjanat/dreamcli/testkit`.
+ */
 export const generate = command('generate')
 	.description(
 		'Rasterize a source image into a multi-size ICO favicon. Optionally also emit per-size '
@@ -179,6 +187,13 @@ export const generate = command('generate')
 		}
 	});
 
+/**
+ * `inject` subcommand: rewrite existing HTML files on disk to include the
+ * configured favicon `<link>` tag set. Strips existing icon links,
+ * preserves `apple-touch-icon`, splices new tags before `</head>`.
+ *
+ * Exported for composition and `runCommand(inject, [...])` testing.
+ */
 export const inject = command('inject')
 	.description(
 		'Rewrite existing HTML files on disk: strip `<link rel="icon">` and `<link rel="shortcut icon">` '
@@ -221,8 +236,9 @@ export const inject = command('inject')
 	)
 	.flag(
 		'input-format',
-		flag.string().default('svg').describe(
-			'Format of `--source` for the MIME type attribute. One of: svg, png, jpg, webp, avif, gif, tiff.',
+		flag.enum(['svg', 'png', 'jpg', 'webp', 'avif', 'gif', 'tiff']).default('svg').describe(
+			'Format of `--source` for the MIME type attribute. Only `svg` triggers the SVG `<link>`; '
+				+ 'other values are accepted but currently inert in tag generation.',
 		),
 	)
 	.example(
@@ -285,6 +301,10 @@ export const inject = command('inject')
 		}
 	});
 
+/**
+ * Top-level `svg-to-ico` CLI: bundles {@link generate} and {@link inject}
+ * subcommands plus shell-completion generation.
+ */
 export const app = cli('svg-to-ico')
 	.description('Generate ICO favicons and inject <link> tags into HTML files')
 	.command(generate)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,8 +9,12 @@
  *
  * @example
  * ```sh
- * vite-svg-to-ico generate src/icon.svg --out-dir build --sizes 16,32,48
- * vite-svg-to-ico inject build/index.html build/404.html --sizes 16,32,48
+ * svg-to-ico generate src/icon.svg --out-dir build --sizes 16,32,48
+ * svg-to-ico inject build/index.html build/404.html --sizes 16,32,48
+ *
+ * Bundled with `vite-svg-to-ico`. The binary is named `svg-to-ico`
+ * because it is not Vite-specific — global install (`bun add -g
+ * vite-svg-to-ico`) makes it available on PATH for any HTML pipeline.
  * ```
  */
 
@@ -154,7 +158,7 @@ export const inject = command('inject')
 		}
 	});
 
-export const app = cli('vite-svg-to-ico')
+export const app = cli('svg-to-ico')
 	.description('Generate ICO favicons and inject <link> tags into HTML files')
 	.command(generate)
 	.command(inject)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,20 +1,42 @@
 #!/usr/bin/env node
 /**
- * vite-svg-to-ico CLI — generate ICO favicons and inject `<link>` tags into
- * HTML files outside of a Vite plugin context.
+ * # svg-to-ico
  *
- * Useful when the host framework writes HTML outside Vite's pipeline
- * (SvelteKit, VitePress, Astro adapters), so the plugin's `transformIndexHtml`
- * never sees the final HTML. Wire as a `"postbuild"` script in `package.json`.
+ * CLI companion to the `vite-svg-to-ico` Vite plugin. Generates multi-size ICO
+ * favicons from any sharp-supported source image, and/or injects favicon
+ * `<link>` tags into existing HTML files.
+ *
+ * ## Why
+ *
+ * Vite's plugin pipeline ends at `closeBundle`. Frameworks that render HTML
+ * outside that pipeline (SvelteKit, VitePress, Astro adapters) write the user-
+ * visible HTML *after* the plugin's last hook fires, so the plugin's built-in
+ * `emit.inject` silently no-ops. This CLI runs as a `"postbuild"` step against
+ * the framework's final on-disk HTML, sidestepping the hook-ordering trap.
+ *
+ * The CLI is also useful for non-Vite pipelines: a one-off ICO generator that
+ * shares the plugin's emit logic (sharp + ICO packer) without dragging Vite
+ * into the equation. Global install with `bun i -g vite-svg-to-ico` (or
+ * `npm i -g vite-svg-to-ico`) puts `svg-to-ico` on PATH.
+ *
+ * ## Subcommands
+ *
+ * - `generate <input>` — rasterize an image to a multi-size ICO (and
+ *   optionally per-size PNGs/ICOs + a copy of the source) on disk.
+ * - `inject <files...>` — rewrite existing HTML files: strip
+ *   `<link rel="icon">`/`<link rel="shortcut icon">` tags, splice the
+ *   configured favicon tag set before `</head>`, preserve `apple-touch-icon`.
  *
  * @example
  * ```sh
- * svg-to-ico generate src/icon.svg --out-dir build --sizes 16,32,48
- * svg-to-ico inject build/index.html build/404.html --sizes 16,32,48
+ * # SvelteKit adapter-static, wired into package.json scripts:
+ * #   "build": "vite build && svg-to-ico inject build/index.html build/404.html -s 16 -s 32 -s 48 --source favicon.svg"
  *
- * Bundled with `vite-svg-to-ico`. The binary is named `svg-to-ico`
- * because it is not Vite-specific — global install (`bun add -g
- * vite-svg-to-ico`) makes it available on PATH for any HTML pipeline.
+ * # Generate a 16/32/48 ICO + per-size PNGs alongside it:
+ * svg-to-ico generate src/icon.svg --out-dir build -s 16 -s 32 -s 48 --emit-sizes png --emit-source
+ *
+ * # Inject favicon links into multiple HTML files at once:
+ * svg-to-ico inject dist/index.html dist/404.html -s 16 -s 32 -s 48 --source favicon.svg --base /app/
  * ```
  */
 
@@ -27,37 +49,76 @@ import { buildFaviconTags, injectTagsIntoHtml } from './html.ts';
 import { generateSizedPngs, packIco } from './ico.ts';
 import { INJECT_MODES, type InjectMode } from './types.ts';
 
-/** Parse comma-separated integer list, validating each is 1–256 per the ICO spec. */
-function parseSizes(raw: string): number[] {
-	const parts = raw.split(',').map((s) => s.trim()).filter(Boolean);
-	if (parts.length === 0) {
-		throw new CLIError('`sizes` must contain at least one value', { code: 'INVALID_ARGUMENT' });
+/** Validate each size is an integer in [1, 256] (ICO spec) and that the list is non-empty. */
+function validateSizes(sizes: number[]): number[] {
+	if (sizes.length === 0) {
+		throw new CLIError('`--sizes` must contain at least one value', { code: 'INVALID_ARGUMENT' });
 	}
-	return parts.map((p) => {
-		const n = Number(p);
+	for (const n of sizes) {
 		if (!Number.isInteger(n) || n < 1 || n > 256) {
-			throw new CLIError(`Invalid size: "${p}". Must be an integer 1–256.`, { code: 'INVALID_ARGUMENT' });
+			throw new CLIError(`Invalid size: ${n}. Must be an integer 1–256.`, { code: 'INVALID_ARGUMENT' });
 		}
-		return n;
-	});
+	}
+	return sizes;
 }
 
 export const generate = command('generate')
-	.description('Generate a multi-size ICO favicon (and optional per-size PNGs) from an image source')
-	.arg('input', arg.string().describe('Path to source image (.svg, .png, .jpg, .webp, .avif, .gif, .tiff)'))
-	.flag('output', flag.string().alias('o').default('favicon.ico').describe('Output ICO filename'))
-	.flag('sizes', flag.string().alias('s').default('16,32,48').describe('Comma-separated pixel sizes (1–256)'))
-	.flag('out-dir', flag.string().alias('d').default('.').describe('Directory to write outputs into'))
+	.description(
+		'Rasterize a source image into a multi-size ICO favicon. Optionally also emit per-size '
+			+ 'PNG/ICO files and a copy of the original source. Equivalent to what the Vite plugin '
+			+ 'emits during `vite build`, but runs standalone.',
+	)
+	.arg(
+		'input',
+		arg.string().describe(
+			'Path to source image. Sharp-supported formats: .svg, .svgz, .png, .jpg/.jpeg, .webp, .avif, .gif, .tif/.tiff.',
+		),
+	)
+	.flag(
+		'output',
+		flag.string().alias('o').default('favicon.ico').describe(
+			'Filename for the combined ICO (relative to --out-dir). May include subdirectories; they are created as needed.',
+		),
+	)
+	.flag(
+		'sizes',
+		flag.array(flag.number()).alias('s').default([16, 32, 48]).describe(
+			'Pixel sizes to rasterize (integers 1–256). Pass repeated: `-s 16 -s 32 -s 48`.',
+		),
+	)
+	.flag(
+		'out-dir',
+		flag.string().alias('d').default('.').describe('Directory to write outputs into. Created if missing.'),
+	)
 	.flag(
 		'emit-sizes',
 		flag.enum(['none', 'png', 'ico', 'both']).default('none').describe(
-			'Also emit per-size files: png, ico, both, or none',
+			'Emit per-size files alongside the combined ICO: `png` (favicon-NxN.png), `ico` (favicon-NxN.ico), `both`, or `none`.',
 		),
 	)
-	.flag('emit-source', flag.boolean().default(false).describe('Copy the source file alongside the ICO'))
-	.flag('no-optimize', flag.boolean().default(false).describe('Disable max PNG compression'))
+	.flag(
+		'emit-source',
+		flag.boolean().default(false).describe(
+			'Copy the original source image into --out-dir (preserves its original basename).',
+		),
+	)
+	.flag(
+		'no-optimize',
+		flag.boolean().default(false).describe(
+			'Skip max PNG compression. Faster builds, larger files. (Default: compression level 9 + adaptive filtering.)',
+		),
+	)
+	.example('svg-to-ico generate src/icon.svg', 'Write favicon.ico (16/32/48) to the current directory.')
+	.example(
+		'svg-to-ico generate src/icon.svg -d build -s 16 -s 32 -s 48 --emit-sizes png --emit-source',
+		'Generate ICO + per-size PNGs + copy of source into build/.',
+	)
+	.example(
+		'svg-to-ico generate src/icon.png -s 64 -s 128 -s 256 -o icons/favicon.ico',
+		'PNG input, custom sizes, nested output path.',
+	)
 	.action(async ({ args, flags, out }) => {
-		const sizes = parseSizes(flags.sizes);
+		const sizes = validateSizes(flags.sizes);
 		const inputPath = resolve(args.input);
 		const outDir = resolve(flags['out-dir']);
 		const outputStem = flags.output.replace(/\.ico$/i, '');
@@ -105,26 +166,75 @@ export const generate = command('generate')
 	});
 
 export const inject = command('inject')
-	.description('Inject favicon `<link>` tags into existing HTML files (strips existing icon links)')
-	.arg('files', arg.string().variadic().describe('HTML file paths to rewrite'))
-	.flag('output', flag.string().alias('o').default('favicon.ico').describe('ICO filename to reference'))
-	.flag('sizes', flag.string().alias('s').default('16,32,48').describe('Comma-separated pixel sizes used in the ICO'))
-	.flag('mode', flag.enum(INJECT_MODES).alias('m').default('minimal').describe('Tag set to inject'))
-	.flag('base', flag.string().default('/').describe('URL base prefix for hrefs (matches Vite `base`)'))
+	.description(
+		'Rewrite existing HTML files on disk: strip `<link rel="icon">` and `<link rel="shortcut icon">` '
+			+ 'tags (preserves `apple-touch-icon`), splice in the configured favicon tag set before `</head>`, '
+			+ 'and write back. The ICO/SVG files themselves are expected to already exist at the configured paths.',
+	)
+	.arg(
+		'files',
+		arg.string().variadic().describe(
+			'HTML file paths to rewrite (one or more). Missing files emit a warning and are skipped, '
+				+ 'but do not fail the run.',
+		),
+	)
+	.flag(
+		'output',
+		flag.string().alias('o').default('favicon.ico').describe(
+			"ICO filename referenced in the injected `<link>` (matches `generate`'s --output).",
+		),
+	)
+	.flag(
+		'sizes',
+		flag.array(flag.number()).alias('s').default([16, 32, 48]).describe(
+			'Pixel sizes baked into the `sizes="…"` attribute (must match the ICO\'s actual contents). '
+				+ 'Pass repeated: `-s 16 -s 32 -s 48`.',
+		),
+	)
+	.flag(
+		'mode',
+		flag.enum(INJECT_MODES).alias('m').default('minimal').describe(
+			'Tag set to inject. `minimal`: ICO + optional SVG source link. `full`: also per-size PNG/ICO links.',
+		),
+	)
+	.flag(
+		'base',
+		flag.string().default('/').describe(
+			"URL base prefix for hrefs (matches Vite's `base` config). Trailing slash is optional; "
+				+ '`--base /app` and `--base /app/` both yield `/app/favicon.ico`.',
+		),
+	)
 	.flag(
 		'source',
-		flag.string().describe('Filename of the emitted source file, enables the SVG `<link>` (e.g. favicon.svg)'),
+		flag.string().describe(
+			'Filename of the source file (e.g. `favicon.svg`). When set, an additional '
+				+ '`<link rel="icon" type="image/svg+xml">` tag is injected.',
+		),
 	)
 	.flag(
 		'input-format',
-		flag.string().default('svg').describe('Source format for MIME type on the SVG `<link>` (svg, png, jpg, ...)'),
+		flag.string().default('svg').describe(
+			'Format of `--source` for the MIME type attribute. One of: svg, png, jpg, webp, avif, gif, tiff.',
+		),
+	)
+	.example(
+		'svg-to-ico inject build/index.html',
+		'Inject default favicon.ico tag (16/32/48) into a single file.',
+	)
+	.example(
+		'svg-to-ico inject build/index.html build/404.html -s 16 -s 32 -s 48 --source favicon.svg',
+		'Multi-file rewrite, also injects SVG source `<link>`.',
+	)
+	.example(
+		'svg-to-ico inject dist/index.html --base /repo/ -m full',
+		'Full tag set under a subpath base (e.g. GitHub Pages project site).',
 	)
 	.action(async ({ args, flags, out }) => {
 		const files = args.files;
 		if (files.length === 0) {
 			throw new CLIError('At least one HTML file path is required', { code: 'INVALID_ARGUMENT' });
 		}
-		const sizes = parseSizes(flags.sizes);
+		const sizes = validateSizes(flags.sizes);
 		const mode = flags.mode as InjectMode;
 		const sourceName = flags.source;
 		const tags = buildFaviconTags({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * vite-svg-to-ico CLI — generate ICO favicons and inject `<link>` tags into
+ * HTML files outside of a Vite plugin context.
+ *
+ * Useful when the host framework writes HTML outside Vite's pipeline
+ * (SvelteKit, VitePress, Astro adapters), so the plugin's `transformIndexHtml`
+ * never sees the final HTML. Wire as a `"postbuild"` script in `package.json`.
+ *
+ * @example
+ * ```sh
+ * vite-svg-to-ico generate src/icon.svg --out-dir build --sizes 16,32,48
+ * vite-svg-to-ico inject build/index.html build/404.html --sizes 16,32,48
+ * ```
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { basename, dirname, resolve } from 'node:path';
+
+import { arg, cli, CLIError, command, flag } from '@kjanat/dreamcli';
+
+import { buildFaviconTags, injectTagsIntoHtml } from './html.ts';
+import { generateSizedPngs, packIco } from './ico.ts';
+import { INJECT_MODES, type InjectMode } from './types.ts';
+
+/** Parse comma-separated integer list, validating each is 1–256 per the ICO spec. */
+function parseSizes(raw: string): number[] {
+	const parts = raw.split(',').map((s) => s.trim()).filter(Boolean);
+	if (parts.length === 0) {
+		throw new CLIError('`sizes` must contain at least one value', { code: 'INVALID_ARGUMENT' });
+	}
+	return parts.map((p) => {
+		const n = Number(p);
+		if (!Number.isInteger(n) || n < 1 || n > 256) {
+			throw new CLIError(`Invalid size: "${p}". Must be an integer 1–256.`, { code: 'INVALID_ARGUMENT' });
+		}
+		return n;
+	});
+}
+
+export const generate = command('generate')
+	.description('Generate a multi-size ICO favicon (and optional per-size PNGs) from an image source')
+	.arg('input', arg.string().describe('Path to source image (.svg, .png, .jpg, .webp, .avif, .gif, .tiff)'))
+	.flag('output', flag.string().alias('o').default('favicon.ico').describe('Output ICO filename'))
+	.flag('sizes', flag.string().alias('s').default('16,32,48').describe('Comma-separated pixel sizes (1–256)'))
+	.flag('out-dir', flag.string().alias('d').default('.').describe('Directory to write outputs into'))
+	.flag(
+		'emit-sizes',
+		flag.enum(['none', 'png', 'ico', 'both']).default('none').describe(
+			'Also emit per-size files: png, ico, both, or none',
+		),
+	)
+	.flag('emit-source', flag.boolean().default(false).describe('Copy the source file alongside the ICO'))
+	.flag('no-optimize', flag.boolean().default(false).describe('Disable max PNG compression'))
+	.action(async ({ args, flags, out }) => {
+		const sizes = parseSizes(flags.sizes);
+		const inputPath = resolve(args.input);
+		const outDir = resolve(flags['out-dir']);
+		const outputStem = flags.output.replace(/\.ico$/i, '');
+
+		const inputBuffer = await readFile(inputPath);
+		const pngs = await generateSizedPngs(inputBuffer, {
+			sizes,
+			optimize: !flags['no-optimize'],
+		});
+		const icoBuffer = packIco(pngs);
+
+		await mkdir(outDir, { recursive: true });
+
+		const icoPath = resolve(outDir, flags.output);
+		await writeFile(icoPath, icoBuffer);
+		out.log(`Wrote ${icoPath} (${icoBuffer.length} B, ${sizes.length} size${sizes.length === 1 ? '' : 's'})`);
+
+		if (flags['emit-source']) {
+			const sourcePath = resolve(outDir, basename(inputPath));
+			await writeFile(sourcePath, inputBuffer);
+			out.log(`Wrote ${sourcePath} (source)`);
+		}
+
+		const emitSizes = flags['emit-sizes'];
+		if (emitSizes !== 'none') {
+			for (const png of pngs) {
+				if (emitSizes === 'png' || emitSizes === 'both') {
+					const p = resolve(outDir, `${outputStem}-${png.size}x${png.size}.png`);
+					await writeFile(p, png.buffer);
+					out.log(`Wrote ${p}`);
+				}
+				if (emitSizes === 'ico' || emitSizes === 'both') {
+					const p = resolve(outDir, `${outputStem}-${png.size}x${png.size}.ico`);
+					await writeFile(p, packIco([png]));
+					out.log(`Wrote ${p}`);
+				}
+			}
+		}
+	});
+
+export const inject = command('inject')
+	.description('Inject favicon `<link>` tags into existing HTML files (strips existing icon links)')
+	.arg('files', arg.string().variadic().describe('HTML file paths to rewrite'))
+	.flag('output', flag.string().alias('o').default('favicon.ico').describe('ICO filename to reference'))
+	.flag('sizes', flag.string().alias('s').default('16,32,48').describe('Comma-separated pixel sizes used in the ICO'))
+	.flag('mode', flag.enum(INJECT_MODES).alias('m').default('minimal').describe('Tag set to inject'))
+	.flag('base', flag.string().default('/').describe('URL base prefix for hrefs (matches Vite `base`)'))
+	.flag(
+		'source',
+		flag.string().describe('Filename of the emitted source file, enables the SVG `<link>` (e.g. favicon.svg)'),
+	)
+	.flag(
+		'input-format',
+		flag.string().default('svg').describe('Source format for MIME type on the SVG `<link>` (svg, png, jpg, ...)'),
+	)
+	.action(async ({ args, flags, out }) => {
+		const files = args.files;
+		if (files.length === 0) {
+			throw new CLIError('At least one HTML file path is required', { code: 'INVALID_ARGUMENT' });
+		}
+		const sizes = parseSizes(flags.sizes);
+		const mode = flags.mode as InjectMode;
+		const sourceName = flags.source;
+		const tags = buildFaviconTags({
+			output: flags.output,
+			sizes,
+			sourceEmitted: !!sourceName,
+			sourceName: sourceName ?? '',
+			inputFormat: flags['input-format'],
+			mode,
+			base: flags.base,
+		});
+
+		let rewritten = 0;
+		for (const rel of files) {
+			const abs = resolve(rel);
+			let original: string;
+			try {
+				original = await readFile(abs, 'utf8');
+			} catch {
+				out.error(`inject: "${rel}" — file not found at ${abs}, skipping`);
+				continue;
+			}
+			const next = injectTagsIntoHtml(original, tags);
+			if (next !== original) {
+				const dir = dirname(abs);
+				await mkdir(dir, { recursive: true });
+				await writeFile(abs, next, 'utf8');
+				rewritten++;
+				out.log(`Rewrote ${rel}`);
+			} else {
+				out.log(`Unchanged ${rel}`);
+			}
+		}
+
+		if (rewritten === 0 && files.length > 0) {
+			out.log('No files were modified.');
+		}
+	});
+
+export const app = cli('vite-svg-to-ico')
+	.description('Generate ICO favicons and inject <link> tags into HTML files')
+	.command(generate)
+	.command(inject)
+	.completions();
+
+if (import.meta.main) {
+	void app.run();
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,14 +71,22 @@ export const generate = command('generate')
 
 		await mkdir(outDir, { recursive: true });
 
+		async function writeAt(targetPath: string, data: Buffer | string, label: string) {
+			await mkdir(dirname(targetPath), { recursive: true });
+			await writeFile(targetPath, data);
+			out.log(label);
+		}
+
 		const icoPath = resolve(outDir, flags.output);
-		await writeFile(icoPath, icoBuffer);
-		out.log(`Wrote ${icoPath} (${icoBuffer.length} B, ${sizes.length} size${sizes.length === 1 ? '' : 's'})`);
+		await writeAt(
+			icoPath,
+			icoBuffer,
+			`Wrote ${icoPath} (${icoBuffer.length} B, ${sizes.length} size${sizes.length === 1 ? '' : 's'})`,
+		);
 
 		if (flags['emit-source']) {
 			const sourcePath = resolve(outDir, basename(inputPath));
-			await writeFile(sourcePath, inputBuffer);
-			out.log(`Wrote ${sourcePath} (source)`);
+			await writeAt(sourcePath, inputBuffer, `Wrote ${sourcePath} (source)`);
 		}
 
 		const emitSizes = flags['emit-sizes'];
@@ -86,13 +94,11 @@ export const generate = command('generate')
 			for (const png of pngs) {
 				if (emitSizes === 'png' || emitSizes === 'both') {
 					const p = resolve(outDir, `${outputStem}-${png.size}x${png.size}.png`);
-					await writeFile(p, png.buffer);
-					out.log(`Wrote ${p}`);
+					await writeAt(p, png.buffer, `Wrote ${p}`);
 				}
 				if (emitSizes === 'ico' || emitSizes === 'both') {
 					const p = resolve(outDir, `${outputStem}-${png.size}x${png.size}.ico`);
-					await writeFile(p, packIco([png]));
-					out.log(`Wrote ${p}`);
+					await writeAt(p, packIco([png]), `Wrote ${p}`);
 				}
 			}
 		}
@@ -137,9 +143,12 @@ export const inject = command('inject')
 			let original: string;
 			try {
 				original = await readFile(abs, 'utf8');
-			} catch {
-				out.error(`inject: "${rel}" — file not found at ${abs}, skipping`);
-				continue;
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+					out.error(`inject: "${rel}" — file not found at ${abs}, skipping`);
+					continue;
+				}
+				throw error;
 			}
 			const next = injectTagsIntoHtml(original, tags);
 			if (next !== original) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,9 +2,9 @@
 /**
  * # svg-to-ico
  *
- * CLI companion to the `vite-svg-to-ico` Vite plugin. Generates multi-size ICO
- * favicons from any sharp-supported source image, and/or injects favicon
- * `<link>` tags into existing HTML files.
+ * CLI companion to the `vite-svg-to-ico` Vite plugin.
+ * Generates multi-size ICO favicons from any sharp-supported source image,
+ * and/or injects favicon `<link>` tags into existing HTML files.
  *
  * ## Why
  *
@@ -49,18 +49,22 @@ import { buildFaviconTags, injectTagsIntoHtml } from './html.ts';
 import { generateSizedPngs, packIco } from './ico.ts';
 import { INJECT_MODES, type InjectMode } from './types.ts';
 
-/** Validate each size is an integer in [1, 256] (ICO spec) and that the list is non-empty. */
-function validateSizes(sizes: number[]): number[] {
-	if (sizes.length === 0) {
-		throw new CLIError('`--sizes` must contain at least one value', { code: 'INVALID_ARGUMENT' });
-	}
-	for (const n of sizes) {
+/**
+ * Build the `--sizes` flag: an array of per-element-validated integers, each
+ * restricted to `[1, 256]` per the ICO spec. Parsing and range-check live
+ * inside the flag definition so the action handler can trust the value.
+ */
+const sizesFlag = () =>
+	flag.array(flag.custom<number>((raw) => {
+		const n = typeof raw === 'number' ? raw : Number(raw);
 		if (!Number.isInteger(n) || n < 1 || n > 256) {
-			throw new CLIError(`Invalid size: ${n}. Must be an integer 1–256.`, { code: 'INVALID_ARGUMENT' });
+			throw new CLIError(`Invalid size: ${String(raw)}. Must be an integer 1–256.`, { code: 'INVALID_SIZE' });
 		}
-	}
-	return sizes;
-}
+		return n;
+	}))
+		.alias('s')
+		.default([16, 32, 48])
+		.describe('Pixel sizes (integers 1–256). Pass repeated: `-s 16 -s 32 -s 48`.');
 
 export const generate = command('generate')
 	.description(
@@ -80,12 +84,7 @@ export const generate = command('generate')
 			'Filename for the combined ICO (relative to --out-dir). May include subdirectories; they are created as needed.',
 		),
 	)
-	.flag(
-		'sizes',
-		flag.array(flag.number()).alias('s').default([16, 32, 48]).describe(
-			'Pixel sizes to rasterize (integers 1–256). Pass repeated: `-s 16 -s 32 -s 48`.',
-		),
-	)
+	.flag('sizes', sizesFlag())
 	.flag(
 		'out-dir',
 		flag.string().alias('d').default('.').describe('Directory to write outputs into. Created if missing.'),
@@ -118,7 +117,7 @@ export const generate = command('generate')
 		'PNG input, custom sizes, nested output path.',
 	)
 	.action(async ({ args, flags, out }) => {
-		const sizes = validateSizes(flags.sizes);
+		const sizes = flags.sizes;
 		const inputPath = resolve(args.input);
 		const outDir = resolve(flags['out-dir']);
 		const outputStem = flags.output.replace(/\.ico$/i, '');
@@ -184,13 +183,7 @@ export const inject = command('inject')
 			"ICO filename referenced in the injected `<link>` (matches `generate`'s --output).",
 		),
 	)
-	.flag(
-		'sizes',
-		flag.array(flag.number()).alias('s').default([16, 32, 48]).describe(
-			'Pixel sizes baked into the `sizes="…"` attribute (must match the ICO\'s actual contents). '
-				+ 'Pass repeated: `-s 16 -s 32 -s 48`.',
-		),
-	)
+	.flag('sizes', sizesFlag())
 	.flag(
 		'mode',
 		flag.enum(INJECT_MODES).alias('m').default('minimal').describe(
@@ -232,9 +225,9 @@ export const inject = command('inject')
 	.action(async ({ args, flags, out }) => {
 		const files = args.files;
 		if (files.length === 0) {
-			throw new CLIError('At least one HTML file path is required', { code: 'INVALID_ARGUMENT' });
+			throw new CLIError('At least one HTML file path is required', { code: 'MISSING_FILES' });
 		}
-		const sizes = validateSizes(flags.sizes);
+		const sizes = flags.sizes;
 		const mode = flags.mode as InjectMode;
 		const sourceName = flags.source;
 		const tags = buildFaviconTags({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,7 @@
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, dirname, resolve } from 'node:path';
+import { cwd } from 'node:process';
 
 import { arg, cli, CLIError, command, flag } from '@kjanat/dreamcli';
 
@@ -64,7 +65,16 @@ const sizesFlag = () =>
 	}))
 		.alias('s')
 		.default([16, 32, 48])
-		.describe('Pixel sizes (integers 1–256). Pass repeated: `-s 16 -s 32 -s 48`.');
+		.describe('Pixel sizes (integers 1–256). Pass repeated: `-s16 -s32 -s48`.');
+
+/** Resolve a raw string to an absolute filesystem path (relative to CWD). */
+const toAbsolutePath = (raw: unknown): string => resolve(String(raw));
+
+/** Reusable absolute-path arg: parsing happens at the schema layer. */
+const pathArg = () => arg.custom<string>(toAbsolutePath);
+
+/** Reusable absolute-path flag: parsing happens at the schema layer. */
+const pathFlag = () => flag.custom<string>(toAbsolutePath);
 
 export const generate = command('generate')
 	.description(
@@ -74,8 +84,9 @@ export const generate = command('generate')
 	)
 	.arg(
 		'input',
-		arg.string().describe(
-			'Path to source image. Sharp-supported formats: .svg, .svgz, .png, .jpg/.jpeg, .webp, .avif, .gif, .tif/.tiff.',
+		pathArg().describe(
+			'Path to source image (resolved to absolute). Sharp-supported formats: .svg, .svgz, .png, '
+				+ '.jpg/.jpeg, .webp, .avif, .gif, .tif/.tiff.',
 		),
 	)
 	.flag(
@@ -87,7 +98,10 @@ export const generate = command('generate')
 	.flag('sizes', sizesFlag())
 	.flag(
 		'out-dir',
-		flag.string().alias('d').default('.').describe('Directory to write outputs into. Created if missing.'),
+		pathFlag().alias('d').default(cwd()).describe(
+			'Directory to write outputs into (resolved to absolute). Created if missing. '
+				+ 'Defaults to the current working directory.',
+		),
 	)
 	.flag(
 		'emit-sizes',
@@ -102,30 +116,31 @@ export const generate = command('generate')
 		),
 	)
 	.flag(
-		'no-optimize',
-		flag.boolean().default(false).describe(
-			'Skip max PNG compression. Faster builds, larger files. (Default: compression level 9 + adaptive filtering.)',
+		'optimize',
+		flag.boolean().default(true).describe(
+			'Apply max PNG compression (level 9 + adaptive filtering). Disable with `--optimize=false` for '
+				+ 'faster builds at the cost of larger files.',
 		),
 	)
-	.example('svg-to-ico generate src/icon.svg', 'Write favicon.ico (16/32/48) to the current directory.')
+	.example('generate src/icon.svg', 'Write favicon.ico (16/32/48) to the current directory.')
 	.example(
-		'svg-to-ico generate src/icon.svg -d build -s 16 -s 32 -s 48 --emit-sizes png --emit-source',
+		'generate src/icon.svg -d build -s16 -s32 -s48 --emit-sizes png --emit-source',
 		'Generate ICO + per-size PNGs + copy of source into build/.',
 	)
 	.example(
-		'svg-to-ico generate src/icon.png -s 64 -s 128 -s 256 -o icons/favicon.ico',
+		'generate src/icon.png -s64 -s128 -s256 -o icons/favicon.ico',
 		'PNG input, custom sizes, nested output path.',
 	)
 	.action(async ({ args, flags, out }) => {
 		const sizes = flags.sizes;
-		const inputPath = resolve(args.input);
-		const outDir = resolve(flags['out-dir']);
+		const inputPath = args.input;
+		const outDir = flags['out-dir'];
 		const outputStem = flags.output.replace(/\.ico$/i, '');
 
 		const inputBuffer = await readFile(inputPath);
 		const pngs = await generateSizedPngs(inputBuffer, {
 			sizes,
-			optimize: !flags['no-optimize'],
+			optimize: flags.optimize,
 		});
 		const icoBuffer = packIco(pngs);
 
@@ -211,15 +226,15 @@ export const inject = command('inject')
 		),
 	)
 	.example(
-		'svg-to-ico inject build/index.html',
+		'inject build/index.html',
 		'Inject default favicon.ico tag (16/32/48) into a single file.',
 	)
 	.example(
-		'svg-to-ico inject build/index.html build/404.html -s 16 -s 32 -s 48 --source favicon.svg',
+		'inject build/index.html build/404.html -s16 -s32 -s48 --source favicon.svg',
 		'Multi-file rewrite, also injects SVG source `<link>`.',
 	)
 	.example(
-		'svg-to-ico inject dist/index.html --base /repo/ -m full',
+		'inject dist/index.html --base /repo/ -m full',
 		'Full tag set under a subpath base (e.g. GitHub Pages project site).',
 	)
 	.action(async ({ args, flags, out }) => {

--- a/src/html.ts
+++ b/src/html.ts
@@ -88,3 +88,40 @@ export function buildFaviconTags(opts: FaviconTagOptions): HtmlTagDescriptor[] {
  * Intentionally does **not** match `apple-touch-icon` so those are preserved.
  */
 export const INJECT_ICON_LINK_RE = /\s*<link\b[^>]*\brel\s*=\s*["'](?:shortcut\s+)?icon["'][^>]*>\s*/gi;
+
+/** Escape double quotes in an attribute value so it can be safely emitted inside `"..."`. */
+function escapeAttr(v: string): string {
+	return v.replace(/"/g, '&quot;');
+}
+
+/** Render a Vite {@link HtmlTagDescriptor} as an HTML string. */
+export function renderTag(tag: HtmlTagDescriptor): string {
+	const attrs = tag.attrs
+		? Object.entries(tag.attrs)
+			.filter(([, v]) => v !== false && v !== undefined && v !== null)
+			.map(([k, v]) => v === true ? k : `${k}="${escapeAttr(String(v))}"`)
+			.join(' ')
+		: '';
+	const open = attrs ? `<${tag.tag} ${attrs}>` : `<${tag.tag}>`;
+	if (tag.children == null) return open;
+	const children = typeof tag.children === 'string'
+		? tag.children
+		: tag.children.map(renderTag).join('');
+	return `${open}${children}</${tag.tag}>`;
+}
+
+/**
+ * Inject favicon `<link>` tags into an HTML document string.
+ *
+ * Strips any existing `icon` / `shortcut icon` links (preserving `apple-touch-icon`)
+ * and inserts the new tags before `</head>`. If no `</head>` is present, tags are
+ * appended at the end of the document.
+ */
+export function injectTagsIntoHtml(html: string, tags: HtmlTagDescriptor[]): string {
+	const cleaned = html.replace(INJECT_ICON_LINK_RE, '');
+	const rendered = tags.map(renderTag).join('\n    ');
+	if (cleaned.includes('</head>')) {
+		return cleaned.replace('</head>', `    ${rendered}\n  </head>`);
+	}
+	return `${cleaned}\n${rendered}`;
+}

--- a/src/html.ts
+++ b/src/html.ts
@@ -35,7 +35,9 @@ export interface FaviconTagOptions {
  */
 export function buildFaviconTags(opts: FaviconTagOptions): HtmlTagDescriptor[] {
 	const tags: HtmlTagDescriptor[] = [];
-	const base = opts.base ?? '/';
+	const baseRaw = opts.base ?? '/';
+	const base = baseRaw.endsWith('/') ? baseRaw : `${baseRaw}/`;
+	const withBase = (name: string) => `${base}${name.replace(/^\/+/, '')}`;
 
 	// 1. ICO — always
 	tags.push({
@@ -43,7 +45,7 @@ export function buildFaviconTags(opts: FaviconTagOptions): HtmlTagDescriptor[] {
 		attrs: {
 			rel: 'icon',
 			type: 'image/x-icon',
-			href: `${base}${opts.output}`,
+			href: withBase(opts.output),
 			sizes: opts.sizes.map((s) => `${s}x${s}`).join(' '),
 		},
 		injectTo: 'head',
@@ -56,7 +58,7 @@ export function buildFaviconTags(opts: FaviconTagOptions): HtmlTagDescriptor[] {
 			attrs: {
 				rel: 'icon',
 				type: 'image/svg+xml',
-				href: `${base}${opts.sourceName}`,
+				href: withBase(opts.sourceName),
 				sizes: 'any',
 			},
 			injectTo: 'head',
@@ -72,7 +74,7 @@ export function buildFaviconTags(opts: FaviconTagOptions): HtmlTagDescriptor[] {
 					rel: 'icon',
 					type: `image/${file.format}`,
 					sizes: `${file.size}x${file.size}`,
-					href: `${base}${file.name}`,
+					href: withBase(file.name),
 				},
 				injectTo: 'head',
 			});
@@ -120,8 +122,10 @@ export function renderTag(tag: HtmlTagDescriptor): string {
 export function injectTagsIntoHtml(html: string, tags: HtmlTagDescriptor[]): string {
 	const cleaned = html.replace(INJECT_ICON_LINK_RE, '');
 	const rendered = tags.map(renderTag).join('\n    ');
-	if (cleaned.includes('</head>')) {
-		return cleaned.replace('</head>', `    ${rendered}\n  </head>`);
+	const headCloseRe = /<\/head>/i;
+	const match = cleaned.match(headCloseRe);
+	if (match) {
+		return cleaned.replace(headCloseRe, `    ${rendered}\n  ${match[0]}`);
 	}
 	return `${cleaned}\n${rendered}`;
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -15,7 +15,7 @@ async function setupTmp(): Promise<string> {
 describe('CLI: generate', () => {
 	it('writes a multi-size favicon.ico to the out dir', async () => {
 		const dir = await setupTmp();
-		const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '16,32']);
+		const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '16', '--sizes', '32']);
 		expect(result.exitCode).toBe(0);
 
 		const stats = await readFile(join(dir, 'favicon.ico'));
@@ -40,7 +40,8 @@ describe('CLI: generate', () => {
 		const result = await runCommand(generate, /* dprint-ignore */ [
 			FIXTURE,
 			'--out-dir', dir,
-			'--sizes', '16,32',
+			'--sizes', '16',
+			'--sizes', '32',
 			'--emit-sizes', 'png',
 		]);
 		expect(result.exitCode).toBe(0);
@@ -55,7 +56,7 @@ describe('CLI: generate', () => {
 
 	it('rejects invalid sizes', async () => {
 		const dir = await setupTmp();
-		const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '0,500']);
+		const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '0', '--sizes', '500']);
 		expect(result.exitCode).not.toBe(0);
 		expect(result.stderr.join('')).toContain('Invalid size');
 	});
@@ -69,7 +70,7 @@ describe('CLI: inject', () => {
 		const file = join(dir, 'index.html');
 		await writeFile(file, HTML);
 
-		const result = await runCommand(inject, [file, '--sizes', '16,32']);
+		const result = await runCommand(inject, [file, '--sizes', '16', '--sizes', '32']);
 		expect(result.exitCode).toBe(0);
 
 		const updated = await readFile(file, 'utf8');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { generate, inject } from '#internals/cli.ts';
+import { runCommand } from '@kjanat/dreamcli/testkit';
+
+const FIXTURE = resolve(import.meta.dirname, 'fixtures/test.svg');
+
+async function setupTmp(): Promise<string> {
+	return mkdtemp(join(tmpdir(), 'vite-svg-to-ico-cli-'));
+}
+
+describe('CLI: generate', () => {
+	it('writes a multi-size favicon.ico to the out dir', async () => {
+		const dir = await setupTmp();
+		const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '16,32']);
+		expect(result.exitCode).toBe(0);
+
+		const stats = await readFile(join(dir, 'favicon.ico'));
+		expect(stats.byteLength).toBeGreaterThan(0);
+		// ICO magic header: reserved (00 00) + type (01 00) + count (02 00 for 2 sizes)
+		expect(stats[0]).toBe(0);
+		expect(stats[2]).toBe(1);
+		expect(stats[4]).toBe(2);
+	});
+
+	it('emits source file when --emit-source is set', async () => {
+		const dir = await setupTmp();
+		const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--emit-source']);
+		expect(result.exitCode).toBe(0);
+
+		const source = await readFile(join(dir, 'test.svg'), 'utf8');
+		expect(source).toContain('<svg');
+	});
+
+	it('emits per-size PNGs when --emit-sizes png is set', async () => {
+		const dir = await setupTmp();
+		const result = await runCommand(generate, /* dprint-ignore */ [
+			FIXTURE,
+			'--out-dir', dir,
+			'--sizes', '16,32',
+			'--emit-sizes', 'png',
+		]);
+		expect(result.exitCode).toBe(0);
+
+		const png16 = await readFile(join(dir, 'favicon-16x16.png'));
+		const png32 = await readFile(join(dir, 'favicon-32x32.png'));
+		// PNG magic: 89 50 4E 47
+		expect(png16[0]).toBe(0x89);
+		expect(png16[1]).toBe(0x50);
+		expect(png32[0]).toBe(0x89);
+	});
+
+	it('rejects invalid sizes', async () => {
+		const dir = await setupTmp();
+		const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '0,500']);
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr.join('')).toContain('Invalid size');
+	});
+});
+
+describe('CLI: inject', () => {
+	const HTML = '<html><head><title>x</title><link rel="icon" href="/old.ico"></head><body></body></html>';
+
+	it('rewrites a single HTML file with minimal mode', async () => {
+		const dir = await setupTmp();
+		const file = join(dir, 'index.html');
+		await writeFile(file, HTML);
+
+		const result = await runCommand(inject, [file, '--sizes', '16,32']);
+		expect(result.exitCode).toBe(0);
+
+		const updated = await readFile(file, 'utf8');
+		expect(updated).toContain('rel="icon"');
+		expect(updated).toContain('href="/favicon.ico"');
+		expect(updated).toContain('sizes="16x16 32x32"');
+		expect(updated).not.toContain('/old.ico');
+	});
+
+	it('preserves apple-touch-icon', async () => {
+		const dir = await setupTmp();
+		const file = join(dir, 'index.html');
+		await writeFile(
+			file,
+			'<html><head><link rel="icon" href="/old.ico"><link rel="apple-touch-icon" href="/apple.png"></head></html>',
+		);
+
+		await runCommand(inject, [file]);
+		const updated = await readFile(file, 'utf8');
+		expect(updated).toContain('apple-touch-icon');
+		expect(updated).not.toContain('/old.ico');
+	});
+
+	it('handles multiple files via variadic arg', async () => {
+		const dir = await setupTmp();
+		const a = join(dir, 'a.html');
+		const b = join(dir, 'b.html');
+		await writeFile(a, '<head></head>');
+		await writeFile(b, '<head></head>');
+
+		const result = await runCommand(inject, [a, b]);
+		expect(result.exitCode).toBe(0);
+		expect(await readFile(a, 'utf8')).toContain('/favicon.ico');
+		expect(await readFile(b, 'utf8')).toContain('/favicon.ico');
+	});
+
+	it('honors --base', async () => {
+		const dir = await setupTmp();
+		const file = join(dir, 'index.html');
+		await writeFile(file, '<head></head>');
+
+		await runCommand(inject, [file, '--base', '/app/']);
+		const updated = await readFile(file, 'utf8');
+		expect(updated).toContain('href="/app/favicon.ico"');
+	});
+
+	it('emits SVG link when --source is provided', async () => {
+		const dir = await setupTmp();
+		const file = join(dir, 'index.html');
+		await writeFile(file, '<head></head>');
+
+		await runCommand(inject, [file, '--source', 'favicon.svg']);
+		const updated = await readFile(file, 'utf8');
+		expect(updated).toContain('type="image/svg+xml"');
+		expect(updated).toContain('href="/favicon.svg"');
+	});
+
+	it('reports missing files but does not fail the run', async () => {
+		const dir = await setupTmp();
+		const present = join(dir, 'present.html');
+		await writeFile(present, '<head></head>');
+
+		const result = await runCommand(inject, [present, join(dir, 'nope.html')]);
+		expect(result.exitCode).toBe(0);
+		const all = [...result.stdout, ...result.stderr].join('\n');
+		expect(all).toContain('file not found');
+		// the present one still got rewritten
+		expect(await readFile(present, 'utf8')).toContain('/favicon.ico');
+	});
+});

--- a/tests/html.test.ts
+++ b/tests/html.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { buildFaviconTags, INJECT_ICON_LINK_RE } from '$/html.ts';
+import { buildFaviconTags, INJECT_ICON_LINK_RE } from '#internals/html.ts';
 
 describe('buildFaviconTags', () => {
 	it('minimal mode: returns ICO tag only for non-SVG input', () => {

--- a/tests/ico.test.ts
+++ b/tests/ico.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'bun:test';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
-import { generateIco, generateSizedPngs, packIco } from '$/ico.ts';
-import type { SizedPng } from '$/ico.ts';
+import { generateIco, generateSizedPngs, packIco } from '#internals/ico.ts';
+import type { SizedPng } from '#internals/ico.ts';
 
 const FIXTURE = resolve(import.meta.dirname, 'fixtures/test.svg');
 

--- a/tests/instrumentation.test.ts
+++ b/tests/instrumentation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { Instrumentation } from '$/instrumentation.ts';
+import { Instrumentation } from '#internals/instrumentation.ts';
 
 describe('Instrumentation', () => {
 	// Note: DEBUG is evaluated at module load time from process.env.DEBUG

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -3,7 +3,7 @@ import { copyFileSync, readFileSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { build, createServer, type InlineConfig, type ViteDevServer } from 'vite';
 
-import svgToIco from '$/index.ts';
+import svgToIco from '#vite-svg-to-ico';
 
 const FIXTURES = resolve(import.meta.dirname, 'fixtures/basic-project');
 const ICON_SVG = join(FIXTURES, 'icon.svg');

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { resolve } from 'node:path';
 
-import svgToIco from '$/index.ts';
+import svgToIco from '#vite-svg-to-ico';
 
 const FIXTURE = resolve(import.meta.dirname, 'fixtures/test.svg');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,7 @@
 		// Some stricter flags
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"noPropertyAccessFromIndexSignature": false,
-
-		"paths": { "$/*": ["./src/*"] }
+		"noPropertyAccessFromIndexSignature": false
 	},
 	"exclude": ["dist"]
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,14 +1,17 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-	entry: 'src/index.ts',
-	dts: true,
+	entry: ['src/index.ts', 'src/cli.ts'],
+	dts: { entry: 'src/index.ts' },
 	exports: {
+		bin: './src/cli.ts',
 		customExports(exports) {
 			const entry = exports['.'];
 			if (typeof entry === 'string') {
 				exports['.'] = { bun: './src/index.ts', default: entry };
 			}
+			// CLI is consumed via the `bin` field, not as a runtime import.
+			delete exports['./cli'];
 			return exports;
 		},
 	},

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
 	entry: ['src/index.ts', 'src/cli.ts'],
 	dts: { entry: 'src/index.ts' },
 	exports: {
-		bin: './src/cli.ts',
+		bin: { 'svg-to-ico': './src/cli.ts' },
 		customExports(exports) {
 			const entry = exports['.'];
 			if (typeof entry === 'string') {


### PR DESCRIPTION
## Summary

Closes the framework-integration gap from #1. Vite's plugin lifecycle can't reach SvelteKit, VitePress, or Astro-adapter HTML (those frameworks write final HTML after `closeBundle`, outside Vite's hook chain) — verified empirically in PR #3. This adds a CLI binary that users wire into a `postbuild` script.

## Commands

| Command | Purpose |
|---|---|
| `vite-svg-to-ico generate <input>` | Produce `favicon.ico` (+ optional per-size PNGs, source copy) from any sharp-supported image |
| `vite-svg-to-ico inject <files...>` | Rewrite existing HTML on disk: strip icon `<link>` tags, splice configured favicons before `</head>`, preserve `apple-touch-icon` |

**Typical SvelteKit usage:**

```json
{
  "scripts": {
    "build": "vite build && vite-svg-to-ico inject build/index.html build/404.html --sizes 16,32,48 --source favicon.svg"
  }
}
```

## Why a CLI instead of a plugin hook

Investigated Vite's plugin API (per [docs](https://vite.dev/guide/api-plugin)):

- `transformIndexHtml` is explicitly documented as "won't be called if you are using a framework that has custom handling of entry files (for example SvelteKit)".
- `closeBundle` is the **last** hook in the lifecycle — there's nothing after.
- SvelteKit/VitePress run their adapter/renderer inside their own `closeBundle`. Even with `enforce: 'post'` they self-position last, so this plugin's `closeBundle` always fires before final HTML exists on disk.

A CLI sidesteps the hook-ordering trap entirely.

## Implementation notes

- Built on `@kjanat/dreamcli` (now a runtime dep; bundled into `dist/cli.mjs`).
- `tsdown` `exports.bin: './src/cli.ts'` auto-detects the shebang and writes the `bin` field into `package.json` at build time.
- Factored `renderTag` + `injectTagsIntoHtml` into `src/html.ts` so the plugin and CLI share one tag-rendering implementation.
- 10 in-process tests via `runCommand` from `@kjanat/dreamcli/testkit` cover both subcommands.

## Drive-by: internal import field migration

Replaced tsconfig path aliases (`$/*`) with Node-spec `package.json` imports field:

```json
"imports": {
  "#vite-svg-to-ico": "./src/index.ts",
  "#internals/*": "./src/*"
}
```

Mirrors the convention used in `@kjanat/dreamcli`.

## Test plan

- [x] `bun test` — 90 pass, 0 fail
- [x] `bun --bun typecheck` — clean
- [x] `bun run build` — attw + publint clean, `dist/cli.mjs` produced with execute permission
- [x] `bun src/cli.ts --help` — surfaces both subcommands
- [x] Smoke test of `generate` + `inject` against a fixture HTML in `/tmp` — round trip works (ICO written, link tags injected, old icons stripped, apple-touch-icon preserved)
- [ ] Verify `bunx vite-svg-to-ico` works after `bun install` in a fresh consumer project (reviewer)
- [ ] Verify SvelteKit `postbuild` flow against `adapter-static` (reviewer)

## Related

- Builds on #2 (warning) which is merged into master as part of v2.2.0.
- PR #3 (`emit.injectScan`) is still open. Once this CLI lands, PR #3 may be redundant for the named frameworks — both attack the same problem from different angles. Will revisit PR #3's fate after this lands.