### PR TITLE
feat(cli)!: default command and input diagnostics

### DIFF
--- a/.dprint.jsonc
+++ b/.dprint.jsonc
@@ -1,5 +1,5 @@
 { // git ls-remote "https://github.com/kjanat/kjanat.git" HEAD | awk '{print substr($1, 1, 8)}' | xargs -r -I{} sed -i -E 's#(github\.com/kjanat/kjanat/raw/)[0-9a-zA-Z]{4,40}(/configs/dprint\.remote\.json)#\1{}\2#g' .dprint.jsonc
-	"extends": "https://github.com/kjanat/kjanat/raw/7d87c3af/configs/dprint.remote.json",
+	"extends": "https://github.com/kjanat/kjanat/raw/1b7194bb/configs/dprint.remote.json",
 	"lineWidth": 120,
 	"typescript": { "module.sortImportDeclarations": "maintain", "module.sortExportDeclarations": "maintain" },
 	"malva": { "useTabs": false },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-08-01
+
 ### Added
 
 - `generate` is now the CLI's **default command**, so `svg-to-ico src/icon.svg`
@@ -668,7 +670,8 @@ svgToIco({
 - Full TypeScript type exports
   (`PluginOptions`, `IconSize`, `IncludeSourceOptions`).
 
-[Unreleased]: https://github.com/kjanat/vite-svg-to-ico/compare/v4.1.0...HEAD
+[Unreleased]: https://github.com/kjanat/vite-svg-to-ico/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/kjanat/vite-svg-to-ico/compare/v4.1.0...v5.0.0
 [4.1.0]: https://github.com/kjanat/vite-svg-to-ico/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/kjanat/vite-svg-to-ico/compare/v3.1.6...v4.0.0
 [3.1.6]: https://github.com/kjanat/vite-svg-to-ico/compare/v3.1.5...v3.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{ error: { code, message, suggest, details } }`.
 - `--no-optimize` as the negated spelling of `--optimize`, rendered
   `--[no-]optimize` in help.
+- `inject --png-sizes`, which injects a per-size
+  `<link rel="icon" type="image/png" sizes="NxN">` for each size given. The
+  plugin could already emit these through a `{ format: 'png', inject }` spec,
+  but the CLI built only ICO and SVG specs, so files written by
+  `generate --emit-sizes png` had no way to be referenced from HTML. Filenames
+  derive from `--output` on both sides, so `-o logo.ico` yields
+  `logo-192x192.png` in the files and in the hrefs; `--embed` inlines the PNG
+  bytes as `data:` URIs like the ICO.
 - `generate --keep-name`, which names the ICO after the source image
   (`logo.svg` -> `logo.ico`, with `--emit-sizes` following the same stem)
   instead of the `favicon.ico` default. Intended for converting a set of icons,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{ error: { code, message, suggest, details } }`.
 - `--no-optimize` as the negated spelling of `--optimize`, rendered
   `--[no-]optimize` in help.
+- `generate --keep-name`, which names the ICO after the source image
+  (`logo.svg` -> `logo.ico`, with `--emit-sizes` following the same stem)
+  instead of the `favicon.ico` default. Intended for converting a set of icons,
+  where the default collapses every source onto one filename; a renamed ICO is
+  no longer auto-requested by browsers and needs its own `<link>` tag. Passing
+  it together with `--output` is an error rather than a silent precedence rule,
+  and `--no-keep-name` opts back out when a wrapper script presets it.
 
 ### Changed (BREAKING)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{ error: { code, message, suggest, details } }`.
 - `--no-optimize` as the negated spelling of `--optimize`, rendered
   `--[no-]optimize` in help.
+- `inject --generate-missing`, which rasterizes any referenced favicon that is
+  not on disk from `--source` and writes it into `--asset-dir`. Without it a
+  missing file is still injected as an href and 404s at run time — `inject`
+  never checked existence on the non-embed path. Existing files are left
+  untouched, and a multi-file run rasterizes each target once.
 - `inject --embed` now rasterizes a missing target from `--source` instead of
   failing. Under `--embed` the href carries the image itself, so nothing has to
   exist at the referenced path — the previous `EMBED_READ` error was demanding
@@ -61,6 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Injected `<link>` tags now copy the document's own whitespace instead of a
+  hardcoded four-space indent: tags take the indentation of the last populated
+  line in `<head>`, `</head>` keeps its own, and the line ending is preserved.
+  A `</head>` that does not start its own line is treated as minified and gets
+  no whitespace at all, so single-line documents stay single-line. Two-space
+  documents render as before.
 - Progress notes (`Wrote …`, `Rewrote …`, `Unchanged …`) moved from stdout to
   stderr as DreamCLI status lines. Stdout is now clean for piping, and the
   advertised `--quiet`/`-q` flag actually silences them — before, it had no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `generate` is now the CLI's **default command**, so `svg-to-ico src/icon.svg`
-  works without a subcommand. Previously a bare path was rejected with
+  works without a subcommand. Previously, a bare path was rejected with
   `Unknown command: src/icon.svg`. The explicit `svg-to-ico generate …` form
   still routes and is listed in help.
 - Actionable diagnostics for a bad `generate` input, replacing raw
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--no-optimize` as the negated spelling of `--optimize`, rendered
   `--[no-]optimize` in help.
 - `inject --generate-missing`, which rasterizes any referenced favicon that is
-  not on disk from `--source` and writes it into `--asset-dir`. Without it a
+  not on disk from `--source` and writes it into `--asset-dir`. Without it, a
   missing file is still injected as an href and 404s at run time — `inject`
   never checked existence on the non-embed path. Existing files are left
   untouched, and a multi-file run rasterizes each target once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `{ error: { code, message, suggest, details } }`.
 - `--no-optimize` as the negated spelling of `--optimize`, rendered
   `--[no-]optimize` in help.
+- `inject --embed` now rasterizes a missing target from `--source` instead of
+  failing. Under `--embed` the href carries the image itself, so nothing has to
+  exist at the referenced path — the previous `EMBED_READ` error was demanding
+  a file the output never points at. Bytes are produced in memory and no image
+  is written; a file on disk still wins, and the error stands when there is no
+  usable `--source`. `sharp` loads through a dynamic import, so a plain
+  `inject` run does not pay for the native module.
 - `inject --png-sizes`, which injects a per-size
   `<link rel="icon" type="image/png" sizes="NxN">` for each size given. The
   plugin could already emit these through a `{ format: 'png', inject }` spec,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `generate` is now the CLI's **default command**, so `svg-to-ico src/icon.svg`
+  works without a subcommand. Previously a bare path was rejected with
+  `Unknown command: src/icon.svg`. The explicit `svg-to-ico generate …` form
+  still routes and is listed in help.
+- Actionable diagnostics for a bad `generate` input, replacing raw
+  `Unexpected error: ENOENT`/`EISDIR` dumps. Each names the file you probably
+  meant and carries a stable error code:
+  - `INPUT_IS_ICO` — the input is an ICO (the format `generate` *writes*);
+    suggests the same-named source beside it and points at `--output`.
+  - `INPUT_NOT_FOUND` — suggests a sibling sharing the basename, otherwise
+    lists the supported images found in that directory.
+  - `INPUT_IS_DIRECTORY` — suggests an image inside the directory.
+- `--json` now emits a summary for both commands instead of nothing:
+  `generate` reports `{ input, ico, sizes, bytes, files }` and `inject` reports
+  `{ rewritten, files: [{ file, status }] }`. Input diagnostics serialize as
+  `{ error: { code, message, suggest, details } }`.
+- `--no-optimize` as the negated spelling of `--optimize`, rendered
+  `--[no-]optimize` in help.
+
+### Changed
+
+- Progress notes (`Wrote …`, `Rewrote …`, `Unchanged …`) moved from stdout to
+  stderr as DreamCLI status lines. Stdout is now clean for piping, and the
+  advertised `--quiet`/`-q` flag actually silences them — before, it had no
+  effect on either command.
+- Help examples resolve the invoked program name at render time, so they read
+  `$ svg-to-ico generate src/icon.svg` rather than a bare `$ generate …`, which
+  looked like the binary was named `generate`.
+- `--output` (both commands) and `--source` (`inject`) reject the empty string
+  at parse time rather than producing a file named after the extension alone.
+- Upgrade `@kjanat/dreamcli` from `^3.0.0-rc.9` to `^3.0.1` and `ansispeck`
+  from `^0.1.2` to `^0.4.1`.
+
 ## [4.1.0] - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--no-optimize` as the negated spelling of `--optimize`, rendered
   `--[no-]optimize` in help.
 
+### Changed (BREAKING)
+
+- `generate` now writes beside the source image when `--out-dir` is omitted, so
+  `svg-to-ico generate public/icon.svg` produces `public/favicon.ico` rather
+  than `./favicon.ico`. `http(s)://` sources have no local directory and keep
+  the current-directory fallback, and an explicit `--out-dir` is unaffected.
+  Scripts that relied on the old cwd default need `--out-dir .` added.
+  `--emit-source` now skips the copy when it would overwrite the source itself.
+
 ### Changed
 
 - Progress notes (`Wrote …`, `Rewrote …`, `Unchanged …`) moved from stdout to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `INPUT_IS_DIRECTORY` — suggests an image inside the directory.
 - `--json` now emits a summary for both commands instead of nothing:
   `generate` reports `{ input, ico, sizes, bytes, files }` and `inject` reports
-  `{ rewritten, files: [{ file, status }] }`. Input diagnostics serialize as
+  `{ rewritten, files: [{ file, status }], generated }`, where `generated` lists
+  any assets `--generate-missing` wrote. Input diagnostics serialize as
   `{ error: { code, message, suggest, details } }`.
 - `--no-optimize` as the negated spelling of `--optimize`, rendered
   `--[no-]optimize` in help.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,18 @@ Both sides derive the per-size filenames from `--output`, so `-o logo.ico`
 yields `logo-192x192.png` in the files and in the hrefs. Under `--embed` the
 PNG bytes are inlined as `data:` URIs like the ICO.
 
+With `--embed` the href carries the image, so nothing needs to exist at the
+referenced path. If a target is missing, it is rasterized from `--source` in
+memory — no image is written to disk, and one HTML rewrite covers the whole
+favicon set:
+
+```sh
+svg-to-ico inject dist/index.html --source favicon.svg --png-sizes 192 --embed
+```
+
+A file already on disk still wins; the run only fails if there is no usable
+`--source` to fall back to.
+
 `generate` is the default command, so the common case needs no subcommand —
 these two are the same invocation:
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ svg-to-ico generate src/icon.svg --out-dir build --sizes 16 --sizes 32 --sizes 4
 svg-to-ico inject build/index.html --sizes 16 --sizes 32 --sizes 48 --source icon.svg
 ```
 
+`inject` writes no images — it rewrites HTML and expects the files to exist
+already. `--png-sizes` links the per-size PNGs that `generate --emit-sizes png`
+produced, giving `<link rel="icon" type="image/png" sizes="192x192">` alongside
+the combined ICO:
+
+```sh
+svg-to-ico generate src/icon.svg -d build -s 192 -s 512 --emit-sizes png
+svg-to-ico inject build/index.html --png-sizes 192 --png-sizes 512
+```
+
+Both sides derive the per-size filenames from `--output`, so `-o logo.ico`
+yields `logo-192x192.png` in the files and in the hrefs. Under `--embed` the
+PNG bytes are inlined as `data:` URIs like the ICO.
+
 `generate` is the default command, so the common case needs no subcommand —
 these two are the same invocation:
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ svg-to-ico inject dist/index.html --source favicon.svg --png-sizes 192 --embed
 A file already on disk still wins; the run only fails if there is no usable
 `--source` to fall back to.
 
+Without `--embed` the href points at a real path, so the file has to exist —
+`inject` does not check, and a missing one 404s at run time. `--generate-missing`
+rasterizes and writes whatever is absent, making a single `inject` call produce
+the whole favicon set:
+
+```sh
+svg-to-ico inject dist/index.html --source favicon.svg --png-sizes 192 --generate-missing
+```
+
+Injected tags copy the document's own indentation — tabs stay tabs, and a
+minified single-line document gains no whitespace.
+
 `generate` is the default command, so the common case needs no subcommand —
 these two are the same invocation:
 

--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ you probably meant:
 
 ```console
 $ svg-to-ico public/favicon.ico
-public/favicon.ico is an ICO — that is what generate writes, not what it reads
-Suggestion: Did you mean 'public/favicon.svg'? The ICO name comes from --output (default favicon.ico)
+Cannot read public/favicon.ico: ICO is an output format, not a source image
+Suggestion: Did you mean 'public/favicon.svg'? The ICO filename comes from --output (default favicon.ico)
 ```
 
 Both commands write their progress notes (`Wrote …`, `Rewrote …`) to stderr, so
@@ -238,7 +238,7 @@ machine-readable summary — or a structured `{ error: { code, suggest } }` — 
 stdout instead.
 
 ```sh
-svg-to-ico src/icon.svg --json | jq -r '.files[]'
+svg-to-ico public/icon.svg --json | jq -r '.files[]'
 ```
 
 Run `svg-to-ico --help` for the full surface.

--- a/README.md
+++ b/README.md
@@ -212,9 +212,14 @@ svg-to-ico inject build/index.html --sizes 16 --sizes 32 --sizes 48 --source ico
 these two are the same invocation:
 
 ```sh
-svg-to-ico src/icon.svg --out-dir public
-svg-to-ico generate src/icon.svg --out-dir public
+svg-to-ico public/icon.svg
+svg-to-ico generate public/icon.svg
 ```
+
+Without `--out-dir`, outputs land **beside the source image**, so the line
+above writes `public/favicon.ico`. Pass `--out-dir` to send them elsewhere;
+`http(s)://` sources have no local directory to sit beside and fall back to the
+current directory.
 
 `<input>` is the **source image to rasterize**, not the ICO to create — the
 ICO filename comes from `--output` (default `favicon.ico`). Pointing `generate`

--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ above writes `public/favicon.ico`. Pass `--out-dir` to send them elsewhere;
 `http(s)://` sources have no local directory to sit beside and fall back to the
 current directory.
 
+The ICO is always named `favicon.ico` unless you say otherwise, because that is
+the name browsers request on their own. `--keep-name` names it after the source
+instead (`logo.svg` → `logo.ico`, and `--emit-sizes` follows the same stem),
+which is what you want when converting a set of icons rather than producing one
+favicon — the default would have every source collapse onto the same
+`favicon.ico`. A renamed ICO is no longer auto-requested, so it needs its own
+`<link>` tag. `--keep-name` and `--output` both name the file, so passing both
+is an error rather than a precedence puzzle.
+
+```sh
+for f in icons/*.svg; do svg-to-ico "$f" --keep-name; done
+```
+
 `<input>` is the **source image to rasterize**, not the ICO to create — the
 ICO filename comes from `--output` (default `favicon.ico`). Pointing `generate`
 at an ICO, a missing file, or a directory fails with a message naming the file

--- a/README.md
+++ b/README.md
@@ -208,6 +208,34 @@ svg-to-ico generate src/icon.svg --out-dir build --sizes 16 --sizes 32 --sizes 4
 svg-to-ico inject build/index.html --sizes 16 --sizes 32 --sizes 48 --source icon.svg
 ```
 
+`generate` is the default command, so the common case needs no subcommand —
+these two are the same invocation:
+
+```sh
+svg-to-ico src/icon.svg --out-dir public
+svg-to-ico generate src/icon.svg --out-dir public
+```
+
+`<input>` is the **source image to rasterize**, not the ICO to create — the
+ICO filename comes from `--output` (default `favicon.ico`). Pointing `generate`
+at an ICO, a missing file, or a directory fails with a message naming the file
+you probably meant:
+
+```console
+$ svg-to-ico public/favicon.ico
+public/favicon.ico is an ICO — that is what generate writes, not what it reads
+Suggestion: Did you mean 'public/favicon.svg'? The ICO name comes from --output (default favicon.ico)
+```
+
+Both commands write their progress notes (`Wrote …`, `Rewrote …`) to stderr, so
+stdout stays clean for piping: `--quiet`/`-q` silences them, and `--json` puts a
+machine-readable summary — or a structured `{ error: { code, suggest } }` — on
+stdout instead.
+
+```sh
+svg-to-ico src/icon.svg --json | jq -r '.files[]'
+```
+
 Run `svg-to-ico --help` for the full surface.
 
 ### Override sharp options

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "vite-svg-to-ico",
       "dependencies": {
-        "ansispeck": "^0.1.2",
-        "dreamcli": "npm:@kjanat/dreamcli@^3.0.0-rc.9",
+        "ansispeck": "^0.4.1",
+        "dreamcli": "npm:@kjanat/dreamcli@^3.0.1",
         "sharp": "^0.35",
       },
       "devDependencies": {
@@ -317,7 +317,7 @@
 
     "ansis": ["ansis@4.3.1", "", {}, "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA=="],
 
-    "ansispeck": ["ansispeck@0.1.2", "", {}, "sha512-C8cz1NraBBRgr0pyr3paCq9qbCIUxDzvCIatE7enZtV8CfTeEiN/difCpHMESr3rCvovahD+IEVNcf7kaw0NRQ=="],
+    "ansispeck": ["ansispeck@0.4.1", "", {}, "sha512-b2M5HQA8Mn8mW2yI/+dVjTrvwgPuocIXrK7GKH8AbR/2Wu27wDW8gI2JlCKMtP18CodsySAifmWQDKi/Ga89Yw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -335,7 +335,7 @@
 
     "dprint": ["dprint@0.55.2", "", { "optionalDependencies": { "@dprint/android-arm64": "0.55.2", "@dprint/android-x64": "0.55.2", "@dprint/darwin-arm64": "0.55.2", "@dprint/darwin-x64": "0.55.2", "@dprint/linux-arm64-glibc": "0.55.2", "@dprint/linux-arm64-musl": "0.55.2", "@dprint/linux-loong64-glibc": "0.55.2", "@dprint/linux-loong64-musl": "0.55.2", "@dprint/linux-ppc64-glibc": "0.55.2", "@dprint/linux-ppc64-musl": "0.55.2", "@dprint/linux-riscv64-glibc": "0.55.2", "@dprint/linux-x64-glibc": "0.55.2", "@dprint/linux-x64-musl": "0.55.2", "@dprint/win32-arm64": "0.55.2", "@dprint/win32-x64": "0.55.2" }, "bin": { "dprint": "bin.cjs" } }, "sha512-1d4D4SB9KiD2qFnBWbl3aoYjLvPVpZoth28yxTT00xJv2yXugdz0Xoyv7sGG0w0hzE6hQZMgd6B333GnySDpGQ=="],
 
-    "dreamcli": ["@kjanat/dreamcli@3.0.0-rc.9", "", { "dependencies": { "ansispeck": "^0.1.2" } }, "sha512-U2jLt5dTGNuby4OC02hXZMCUwyf3IhQGNXj88Krq34gqgYOgAFoqBEWMflumCmTIbkZ452VJW42j+48Uv4fEMw=="],
+    "dreamcli": ["@kjanat/dreamcli@3.0.1", "", { "dependencies": { "ansispeck": "^0.4.1" } }, "sha512-FY5uBPI7EQouhyUEpQdMEVew4jGEcshBZSSH6a8G47Bie+uBk1flLj8l2sJrVDOyd9lG1i1BaYyV0jmgdENp3A=="],
 
     "dts-resolver": ["dts-resolver@3.0.0", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@typescript/native": "npm:typescript@^7",
         "dprint": "^0.55.1",
         "publint": "^0.3",
-        "runner-run": "^0.19.1",
+        "runner-run": "^0.24.0",
         "sort-package-json": "^4.0.0",
         "tsdown": "^0.22",
         "typescript": ">=6,<7",
@@ -33,23 +33,23 @@
 
     "@arethetypeswrong/core": ["@arethetypeswrong/core@0.18.5", "", { "dependencies": { "@andrewbranch/untar.js": "^1.0.3", "@loaderkit/resolve": "^1.0.2", "cjs-module-lexer": "^1.2.3", "fflate": "^0.8.3", "lru-cache": "^11.0.1", "semver": "^7.5.4", "typescript": "5.6.1-rc", "validate-npm-package-name": "^5.0.0" } }, "sha512-9ytjzGwxjm9Uz7I9avfbt5vlQt6uk9uRRESzJjqrznl6WKvI6dwYTo+vJ3U02Wrq/mR3iql/PzhvHhKdJIAjDQ=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.3", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.3", "@biomejs/cli-darwin-x64": "2.5.3", "@biomejs/cli-linux-arm64": "2.5.3", "@biomejs/cli-linux-arm64-musl": "2.5.3", "@biomejs/cli-linux-x64": "2.5.3", "@biomejs/cli-linux-x64-musl": "2.5.3", "@biomejs/cli-win32-arm64": "2.5.3", "@biomejs/cli-win32-x64": "2.5.3" }, "bin": { "biome": "bin/biome" } }, "sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.6", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.6", "@biomejs/cli-darwin-x64": "2.5.6", "@biomejs/cli-linux-arm64": "2.5.6", "@biomejs/cli-linux-arm64-musl": "2.5.6", "@biomejs/cli-linux-x64": "2.5.6", "@biomejs/cli-linux-x64-musl": "2.5.6", "@biomejs/cli-win32-arm64": "2.5.6", "@biomejs/cli-win32-x64": "2.5.6" }, "bin": { "biome": "bin/biome" } }, "sha512-lxVNjv7UF6KfhMJfL9gaUHbWdJdHbsAj6OSmwSYNdhRuG67NxNQ4Xdvh3TUxsSK9sBzJBQhEJj3AopmmNJ5pSA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zMOLZP4oMrjh6m1zcSj1ud2awUPgTuMVbmQhYYWL7J8HwCnbHHBvTm7VBTRuY7epT5bez76IpKYQ11ZAqHFlnw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-JAC1VqzvO7Th5ZplU0G2uGfkZbxEe9uDDektPAhF0JLusoz1w+T4okp2bkykI0bbaO2vslKiRfj4gU43JaGreA=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-6XsYwCFkp5sMxl85ffhgeGpGgs6A7dRYFnkceZ7WVxvycuTnGdD5xa534Z3xfrBQ0JCMK/mujT6ZNPJoghedwg=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-eUa3jeeYvfMt19LBeh6E5PUZpxnTC4JqNWo+EDjTtQjAr2xLGnWaxACtVU1DQqmHYbvThlJzLX+ZsYgrqh2qVw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-Pop9VXCFUhFTMfFefZ39S+u2rOPyNp5iHlxbZRwXGACHLy2r0jjiRgJHmaEKJzL3SyxlVeGShXhvvElvWowonA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.3", "", { "os": "linux", "cpu": "x64" }, "sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-2Vp13QdKysH3HIWLaYLhUUwbK+jbZonJD1K+Lr0d0RO4wH7mkYd43vJixEDm8cUWrowoRz4UUHF1nm9Ae7ym8A=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-tDGshcm6BdkZOCGnTDX0Y8/U4IfBSlnUU7T56nNDuPEfed+aHg+u8G36NB43fJVl0Os6+QURXIE1yuD7AaEofA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.3", "", { "os": "win32", "cpu": "x64" }, "sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-WN05KwXnTO/2J45RQPvzZMXf7tZUIofHoR35xIPfCo7pQ2RFidxI8sfb5mGsaTxdMmEOzHzOPRCdA5/fCpc7xQ=="],
 
     "@braidai/lang": ["@braidai/lang@1.1.2", "", {}, "sha512-qBcknbBufNHlui137Hft8xauQMTZDKdophmLFv05r2eNmdIv/MlPuP4TdUknHG68UdWLgVZwgxVe735HzJNIwA=="],
 
@@ -83,11 +83,11 @@
 
     "@dprint/win32-x64": ["@dprint/win32-x64@0.55.2", "", { "os": "win32", "cpu": "x64" }, "sha512-UTiDSShHbrkx+z719/MffgwGYD8PaypdVmG4vVJVjmF5Hoin6EfugHhSoBf8+G6U9rF+uDIIl0idZq+6Bifzwg=="],
 
-    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+    "@emnapi/core": ["@emnapi/core@2.0.0-alpha.3", "", { "dependencies": { "@emnapi/wasi-threads": "2.0.1", "tslib": "^2.4.0" } }, "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+    "@emnapi/runtime": ["@emnapi/runtime@2.0.0-alpha.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA=="],
 
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@2.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -155,71 +155,73 @@
 
     "@loaderkit/resolve": ["@loaderkit/resolve@1.0.6", "", { "dependencies": { "@braidai/lang": "^1.0.0" } }, "sha512-G8FdIoF5CypfwmD9rl8BXod5HDn8JqB0CCNBXDTaRZ+yRYhARrrSToX1zg1zy9jX3zLqigsELwhT4gNtkdQAUg=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3" } }, "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+    "@oxc-project/types": ["@oxc-project/types@0.142.0", "", {}, "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ=="],
 
-    "@publint/pack": ["@publint/pack@0.1.5", "", { "dependencies": { "tinyexec": "^1.2.4" } }, "sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw=="],
+    "@publint/pack": ["@publint/pack@0.1.6", "", { "dependencies": { "tinyexec": "^1.2.4" } }, "sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA=="],
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.1", "", { "os": "none", "cpu": "arm64" }, "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.2.1", "", { "dependencies": { "@emnapi/core": "2.0.0-alpha.3", "@emnapi/runtime": "2.0.0-alpha.3", "@napi-rs/wasm-runtime": "^1.2.0" } }, "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
-    "@runner-run/darwin-arm64": ["@runner-run/darwin-arm64@0.19.1", "", { "os": "darwin", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-tFWMsiLh25+E1CjgGbjVJtPHTMRnEzgYGYrE1re9G3hdYHAjHNSBuxUp97cp/LCuN/pzIXX6QXBuxPGJvWhkhg=="],
+    "@runner-run/android-arm64": ["@runner-run/android-arm64@0.24.0", "", { "os": "android", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-AYo4PAsY+sykhu+g16J/jgZ/C9Q9wdjLobUxuP76EJp/mR/KjIBW1JHdE5oD88GZ0uNYfeDu2hfkeuZ6JGrjGQ=="],
 
-    "@runner-run/darwin-x64": ["@runner-run/darwin-x64@0.19.1", "", { "os": "darwin", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-x5e+qfSekQh4y0lb4yb6W0iGmewoUDWUsMCuznxrZEfJDPTVILNo4CRRlZ9GmOWU9uZB5ZCLMmPcRsGFa8G+Rw=="],
+    "@runner-run/darwin-arm64": ["@runner-run/darwin-arm64@0.24.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-7MoPrZRP8t8l6BbvaTedBkux0Bd6o7Y85F2VOXE/kdSzMe0nHLJKQPXqON5kUQYaUKPUpo5vLSGBeFc7LNdQEQ=="],
 
-    "@runner-run/freebsd-arm64": ["@runner-run/freebsd-arm64@0.19.1", "", { "os": "freebsd", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-4NgTvoB+vCGAnWXhpCHX52blHVYWlu0fiebTcA6dJ+le4BlA/Bo8ZQAmDqY1njkQJ5wE7rVH699I5gqqYhKaCQ=="],
+    "@runner-run/darwin-x64": ["@runner-run/darwin-x64@0.24.0", "", { "os": "darwin", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-mVJgoIPCI5WBKGCnJj3nrJ39QZg8TURM64KC3o0o3TtMAN2SQQlWG8lhhpHORMec2MOXLAvkb4QLMUR3zFBzSw=="],
 
-    "@runner-run/freebsd-x64": ["@runner-run/freebsd-x64@0.19.1", "", { "os": "freebsd", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-vc//DtuzH5oKBMmJteTg6zrDhupGXSxd8qrVexNXOg4+URzW45V90DMh1K37mrw4jT96vIIKhHf1c7vLNXkNAw=="],
+    "@runner-run/freebsd-arm64": ["@runner-run/freebsd-arm64@0.24.0", "", { "os": "freebsd", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-Txb+eIeppyNA9KUdGe97ddRMgmOKxZsHLv6GGB/soxpFNLjfwfDwRKpWArQ4qYRxd3+a6ji/NuwGDqYnaWcxnQ=="],
 
-    "@runner-run/linux-arm64-gnu": ["@runner-run/linux-arm64-gnu@0.19.1", "", { "os": "linux", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-AQM7g1rLGz27waxqvf+4muzz2gfVqSbmb9ZDdW3aIrD2R7NqwPoLsDSnFX30TcLESMAOGHkeMq9D2ixFkbu0Qg=="],
+    "@runner-run/freebsd-x64": ["@runner-run/freebsd-x64@0.24.0", "", { "os": "freebsd", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-zkMIzndJOEPK60Y2+mqZ2koMqrpcblKX5ZtXeXEOZSVCoH0h83B1NxS2R0UjDoK45X250b/70aifVr8BIRKM9g=="],
 
-    "@runner-run/linux-arm64-musl": ["@runner-run/linux-arm64-musl@0.19.1", "", { "os": "linux", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-0ndZbZfBfkV2CJfCADnQ4QDj3/3ywf9nKnRd/WvlOkiXmlJYwK605jxxgh03E21SB7c1G9/vaznsT/+1F1idXw=="],
+    "@runner-run/linux-arm64-gnu": ["@runner-run/linux-arm64-gnu@0.24.0", "", { "os": "linux", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-sertsQhZaewzPhsDSsPPqPKU5VGuEuC/rCG3Tc7oRQ8kiSztkwKIkzYp+z9uNlLJOpmEkLtv11zPB+2pX8mfnA=="],
 
-    "@runner-run/linux-armv7-gnueabihf": ["@runner-run/linux-armv7-gnueabihf@0.19.1", "", { "os": "linux", "cpu": "arm", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-jpCbRhsLnRVLYpWPjOrbltov5qmXch3+qfg/6WPQRw7c5cE+nqT9jRVjj/E3zyBw3gXRu6bjJHoJ2eTZMQ0J2w=="],
+    "@runner-run/linux-arm64-musl": ["@runner-run/linux-arm64-musl@0.24.0", "", { "os": "linux", "cpu": "arm64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-eofqW+nzCP/oN8LhsnUIKqT8xaAoWxLoKJ8yKm62Egk6a8gSE3IsPx8NL/sfWd0475X362wJR0X/zxWqgOBn1w=="],
 
-    "@runner-run/linux-x64-gnu": ["@runner-run/linux-x64-gnu@0.19.1", "", { "os": "linux", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-gbNXQEgHqSTDo5UResezLWiUxzcTvhP4w1pEYEjco/aYVjCbxEZyVlFm7S6GNzer7wlMKbygTKHcKVWhjCckSA=="],
+    "@runner-run/linux-armv7-gnueabihf": ["@runner-run/linux-armv7-gnueabihf@0.24.0", "", { "os": "linux", "cpu": "arm", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-AAEkV77s9OwJrZjibd2waA5SmQR+tf5pMMDMf2AEPxNOHinRwSXtSmBcLSBrDNQiOdykHqhhftYeG1NjAQyf/A=="],
 
-    "@runner-run/linux-x64-musl": ["@runner-run/linux-x64-musl@0.19.1", "", { "os": "linux", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-5WBQia8Cq5JGqBr6Lx9Sk/aVeaoeL363h1t+U9KsxQaRH/sMuPEiGsN3nugiuVF5Lbxe1xeuNTEs+vpB45r+yg=="],
+    "@runner-run/linux-x64-gnu": ["@runner-run/linux-x64-gnu@0.24.0", "", { "os": "linux", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-fE51ovGiefpSp/WrFxV3lawgU2C35jNZyA/vHj41cpracJQwYUqaeZLn/Odl/LnAmmfOVMbZNEEElJfYa73nCg=="],
 
-    "@runner-run/netbsd-x64": ["@runner-run/netbsd-x64@0.19.1", "", { "os": "none", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-yCiwI3ou+e4aYG8mOtGQK5U6gZubB9oEZC3XyrPuXdRFdK1/dkbcRRjsLXl7UJ8N6F/2sO5nLC6HHk87lyzlSA=="],
+    "@runner-run/linux-x64-musl": ["@runner-run/linux-x64-musl@0.24.0", "", { "os": "linux", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-7Sf3odoSl1wqQUustIEI4oeW7rMFAgnntqw13YgxqgfQ32YRy8z6d1z3U+4kbfA1BzWlmCQmwPhjmr7+K+F9AQ=="],
 
-    "@runner-run/win32-arm64-msvc": ["@runner-run/win32-arm64-msvc@0.19.1", "", { "os": "win32", "cpu": "arm64", "bin": { "runner": "bin/runner.exe", "run": "bin/run.exe" } }, "sha512-9xc6SFmdHCYP4/4LRgAhE2Ne4fVIthnex6mhciYvqXuG8Tfq7wSdTtmqWa615XcWZp0ULR++FbNrLZnc9TLyRg=="],
+    "@runner-run/netbsd-x64": ["@runner-run/netbsd-x64@0.24.0", "", { "os": "none", "cpu": "x64", "bin": { "runner": "bin/runner", "run": "bin/run" } }, "sha512-2UF91EDFAcXG5u+drj+2V8qbNhmwzinqtgfIGsClXl0b+l0R0j5H4bkgIDJTnKgr5ifAM0jPR1M0EzhMX0VIiA=="],
 
-    "@runner-run/win32-ia32-msvc": ["@runner-run/win32-ia32-msvc@0.19.1", "", { "os": "win32", "cpu": "ia32", "bin": { "runner": "bin/runner.exe", "run": "bin/run.exe" } }, "sha512-KDR4KhJnL6ukFP+3luYZJhI+RpXVxYwKcu+F6ecWVZV6eAGwh2ftOTl+C4XecpKROv1f6ulYJP9OoEjFHD9Zdg=="],
+    "@runner-run/win32-arm64-msvc": ["@runner-run/win32-arm64-msvc@0.24.0", "", { "os": "win32", "cpu": "arm64", "bin": { "runner": "bin/runner.exe", "run": "bin/run.exe" } }, "sha512-syX1aobOU/iR9Kaag4QXxGPHX3DKN/1d2mfP2HWCwXKBBIahHJFG9pCdFfX0WyTKZ7FIXqDmcUwqSb78OU0l6w=="],
 
-    "@runner-run/win32-x64-msvc": ["@runner-run/win32-x64-msvc@0.19.1", "", { "os": "win32", "cpu": "x64", "bin": { "runner": "bin/runner.exe", "run": "bin/run.exe" } }, "sha512-FXbzAa1gkt+kRS5+7pNWU81fDtrMOkXe/AAXW0Nq3/w/YMu/U9XjDB1rfZ+5QaSSCFk7DqRzhfGww2sDe2BIeQ=="],
+    "@runner-run/win32-ia32-msvc": ["@runner-run/win32-ia32-msvc@0.24.0", "", { "os": "win32", "cpu": "ia32", "bin": { "runner": "bin/runner.exe", "run": "bin/run.exe" } }, "sha512-8OEsDBJMOoOMtJC5B6TBvd7gAUtzjGIvIN8PAA9dAE98I5Ec9+5Dglldwhi0A6zSsuB2vrZv/R05nsJM6eTO1A=="],
+
+    "@runner-run/win32-x64-msvc": ["@runner-run/win32-x64-msvc@0.24.0", "", { "os": "win32", "cpu": "x64", "bin": { "runner": "bin/runner.exe", "run": "bin/run.exe" } }, "sha512-2Xm9zS4uVOOsr9wkFXrIc37UsdhOcutr4OWgg0uos9EsLZ0O/YcJvs2uBQDX9nxQEBvQZ5WmNTPbZY6cY+r6Kw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -269,51 +271,51 @@
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
-    "@yuku-codegen/binding-darwin-arm64": ["@yuku-codegen/binding-darwin-arm64@0.6.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pbDcFygFmbvo0jGFq5U0m5Sa9U8aVttVJWbBHZDZ68w/X48HdDWS1V4XvBacs8XkmWbTr/ef5fMGG7HsngqTmg=="],
+    "@yuku-codegen/binding-darwin-arm64": ["@yuku-codegen/binding-darwin-arm64@0.8.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jphw5TTa0heJQ23YGkiOHyenSpxFVV+w6pJGTfQANq2mfPmlsSsJsZ/ZTjxPu1VRlZLIPyuVH5TIB7wdpYg3AA=="],
 
-    "@yuku-codegen/binding-darwin-x64": ["@yuku-codegen/binding-darwin-x64@0.6.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-qZMrnA4i8OfqL3NMGoOvLdh1vby8cCGsmNo+tJQIIezXO557m3fdQLenz/57GqtBnnGWzWqd/aDp+faNxWlLwQ=="],
+    "@yuku-codegen/binding-darwin-x64": ["@yuku-codegen/binding-darwin-x64@0.8.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-sBvF/E8R4fnzTPN5/zYoJiIyX/TJHgjJs6QEEpUxWF6VA4NiEKR1CP2IWwZR7NMx0d2x/ZmfeOPC+BD3qXakBQ=="],
 
-    "@yuku-codegen/binding-freebsd-x64": ["@yuku-codegen/binding-freebsd-x64@0.6.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-2+SFpfem2GBH6BlCTAq6R44bZwuieduwRWHkCQnSgbK8tdEjMwB0Ix0IchryVBn6hdiWCZSTkSE3UILliRXsRQ=="],
+    "@yuku-codegen/binding-freebsd-x64": ["@yuku-codegen/binding-freebsd-x64@0.8.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QZx/eDl84slDG6iNo7Dwn5wNbJiYYqfYW0gmLZ09U7UXr/HSHS/hc8mxw5IZAN+c7qe02NsZIlRQG2XfryE2lA=="],
 
-    "@yuku-codegen/binding-linux-arm-gnu": ["@yuku-codegen/binding-linux-arm-gnu@0.6.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fbxg3cBPdJ++36DXtdzcoKw2xzFov91Wxvmn1khX9MXQbDqJQLJmITZhtokcZsj4uGJe32sUmxAZnKbUtZLjmA=="],
+    "@yuku-codegen/binding-linux-arm-gnu": ["@yuku-codegen/binding-linux-arm-gnu@0.8.2", "", { "os": "linux", "cpu": "arm" }, "sha512-ECjv/naK2fa5ukNicK6hNcdacs7po+bqlE6AlTgBLXF0mSalSm4SGGlcSShIrxpoWs5wlyuJG1IuRwZcFscefA=="],
 
-    "@yuku-codegen/binding-linux-arm-musl": ["@yuku-codegen/binding-linux-arm-musl@0.6.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Jk4P7kocGEisSvUFIm1VuHO3hC01LvS3sYAAmVVu1/ve5TuZ0iXyl9kIGtd1ZrgUvchgvZWNOaB+/Kq/RO63FA=="],
+    "@yuku-codegen/binding-linux-arm-musl": ["@yuku-codegen/binding-linux-arm-musl@0.8.2", "", { "os": "linux", "cpu": "arm" }, "sha512-ZSUk8MHq1V+iMI2ATjOYzZ1cQOGxAkupwB7KJ4EYVQhkFscQQ5afOEODlIUcspiPbO44WsC3i0Gj5O+ruevgCg=="],
 
-    "@yuku-codegen/binding-linux-arm64-gnu": ["@yuku-codegen/binding-linux-arm64-gnu@0.6.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-i1xE8Bx1YZLheWtBZHD0Mq3nAIDrhgiH7o8VB4GiCbHufKb4XKj4CqSDMWSC0RYPmn//E+UEd1NsE2NbOux1tQ=="],
+    "@yuku-codegen/binding-linux-arm64-gnu": ["@yuku-codegen/binding-linux-arm64-gnu@0.8.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZ3I2Kzg4sAm4zUGigtl5966T3otCmSVDMQGKc60GpI9JgTOLZ5EiaooUda+e6RZQrkluIG4YD+fTtKYIEHu+g=="],
 
-    "@yuku-codegen/binding-linux-arm64-musl": ["@yuku-codegen/binding-linux-arm64-musl@0.6.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZeLkC6xZrlDoIJTadHfqTABTmsj2f6wCCtYBYx/RPGgdmQcGLA0NALRl7m0tnK2CT45eNRuOYzsfEZyF0XWM/A=="],
+    "@yuku-codegen/binding-linux-arm64-musl": ["@yuku-codegen/binding-linux-arm64-musl@0.8.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-xHa/054f50MKZl5S1FGQET3gCeXZN751yBuSDS3+3YwGxDNdoIvB3BksGse2wVyTz79kMSwG0NymeuorKAVehw=="],
 
-    "@yuku-codegen/binding-linux-x64-gnu": ["@yuku-codegen/binding-linux-x64-gnu@0.6.3", "", { "os": "linux", "cpu": "x64" }, "sha512-HNYt7zjIChPcnjZRG42CZq3Zn5mqaRo4UcFLr4mIbmGqdhX5hDDE8O8US8YgYyOUosfbBTBFdsbvFwVAx1TOkQ=="],
+    "@yuku-codegen/binding-linux-x64-gnu": ["@yuku-codegen/binding-linux-x64-gnu@0.8.2", "", { "os": "linux", "cpu": "x64" }, "sha512-nKLb7AU6A/pQk8gS/EEoRK7AarvczmIv7P2UyWTcp5eXGQ+qI/7tmKz67pgcY/2GjcATKlNA1OOCQ60sqWsMNQ=="],
 
-    "@yuku-codegen/binding-linux-x64-musl": ["@yuku-codegen/binding-linux-x64-musl@0.6.3", "", { "os": "linux", "cpu": "x64" }, "sha512-/1ttT31dAQc7hGtXWSEYEgzGtakAyO2C+/GqAzIuKXlGLpNPZgXdR8LZ0iDHDalbEr3AuHIPRV43sWLUrHWdsA=="],
+    "@yuku-codegen/binding-linux-x64-musl": ["@yuku-codegen/binding-linux-x64-musl@0.8.2", "", { "os": "linux", "cpu": "x64" }, "sha512-TGUZYRhrO21ZyjP/MMma0qSzfWqo//aMc/DTiOk3MgD+H7wWTPun4FsEufheGYgHPptCke2yqiiJGaH+o/9D2w=="],
 
-    "@yuku-codegen/binding-win32-arm64": ["@yuku-codegen/binding-win32-arm64@0.6.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-oAArRDU1lkKg+xFEtiQ7C+/wghpqrkBrFWM05W73S+3sZz8JIHH79Q+Qh5gWls3i8vccitUgCnvln5V7xKn3XQ=="],
+    "@yuku-codegen/binding-win32-arm64": ["@yuku-codegen/binding-win32-arm64@0.8.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-q8c+d0BHUXAVk9hUuozD+VqoNYCl7cCmd3hKddjGUo5EmHK/iPro7bX0WJ0XeuJJewja4KTXg2Q2Ru3QOqd83g=="],
 
-    "@yuku-codegen/binding-win32-x64": ["@yuku-codegen/binding-win32-x64@0.6.3", "", { "os": "win32", "cpu": "x64" }, "sha512-bhFDcDsvmp5KuBfWTt4carNo1E4LXH7++S8qqZgDtXVqJxs0xMm7gbuqPihA8kBbphM+NzAUm5qmq6ocfqM6kg=="],
+    "@yuku-codegen/binding-win32-x64": ["@yuku-codegen/binding-win32-x64@0.8.2", "", { "os": "win32", "cpu": "x64" }, "sha512-rQLrBqyBYhK+ScykCedXv7E88ddrHH27GS85vyHpCx1SYxJD4HlGfDyCMP+qvuwkyNs7AIgcJ/xIAknrH+t/pg=="],
 
-    "@yuku-parser/binding-darwin-arm64": ["@yuku-parser/binding-darwin-arm64@0.6.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Xate6yyZgvi7da/gdnZy+Vu5jlFB0LRlb5m4MY6Y98KSQeJPZIhoVXMK2Vsl48XOmPlDIS8lge414HUVUEo+hg=="],
+    "@yuku-parser/binding-darwin-arm64": ["@yuku-parser/binding-darwin-arm64@0.8.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-kgbuuJAM2T99hnROb/N79pFBT/HrmEOWKFYN6+gmZWTaGG+JAYaCBKMGiOQA97tWkbGgRHMbAdn5AkKDcP4VnA=="],
 
-    "@yuku-parser/binding-darwin-x64": ["@yuku-parser/binding-darwin-x64@0.6.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-WKMZ5UU2HBdGZDEpQoLq+21f1FlS+BjroH1FaVE6zCSeqKmZ7xRP5jIRGtQ4vCYj/k2KHgyABZ16lgK9mTe2Sg=="],
+    "@yuku-parser/binding-darwin-x64": ["@yuku-parser/binding-darwin-x64@0.8.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-b957p6PfpWdgziR//GB7em5ah557PcsRkTqXtRiG+mK6LA4yulnZWFoQJpjPcwbNyYCMXMVkuQOds7Qa9VKNIA=="],
 
-    "@yuku-parser/binding-freebsd-x64": ["@yuku-parser/binding-freebsd-x64@0.6.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-OWX8V2k4bmtl/DNwU3yz3PZa2QXiSqWN3Xk7pNB5IPt7FcJBDlnpkOcX6h3tjMS7CyKE0lMvPUwwcmWSdbjkyA=="],
+    "@yuku-parser/binding-freebsd-x64": ["@yuku-parser/binding-freebsd-x64@0.8.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-kMYxxeSRaCpp0bjwUMuoZulf1/QxWBf4jhtdFJU4f8+USHL8Pzb1q0kg5NO1XNUkxlc9wAE4aieS5n/WHY8qjg=="],
 
-    "@yuku-parser/binding-linux-arm-gnu": ["@yuku-parser/binding-linux-arm-gnu@0.6.3", "", { "os": "linux", "cpu": "arm" }, "sha512-/4LzmPXPaCWqIpY1j3+XVb8rbXIratqCte3A4sGEjua6aVhvVxEVAqeKlBsoGkORWLeqbpcxhgxKwOGM17eexA=="],
+    "@yuku-parser/binding-linux-arm-gnu": ["@yuku-parser/binding-linux-arm-gnu@0.8.2", "", { "os": "linux", "cpu": "arm" }, "sha512-mC3u9kYB0ypXwXrT3Jf4g47HKJBbw+fltNp2zd5vUOXjOlx9RmDHhny00V0eHWkZ4xkpOwrolH5KhbA7KB3mIA=="],
 
-    "@yuku-parser/binding-linux-arm-musl": ["@yuku-parser/binding-linux-arm-musl@0.6.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Df4jk0M/eNKKQfYzXBBKhKkmJBpB+XoX2LkMxmlK3GN+fxUdeb8EM78wX+1+eLVl5dZNo6f7gOd6oDV0gChevw=="],
+    "@yuku-parser/binding-linux-arm-musl": ["@yuku-parser/binding-linux-arm-musl@0.8.2", "", { "os": "linux", "cpu": "arm" }, "sha512-g78kWFRpkLBQZVYilzA1a4kvlYBModKEn5wHqoo4GJVtPWlKl3EUa6E6oHWzlpy/a0YwwBKF9Z/I1GxNz64FJg=="],
 
-    "@yuku-parser/binding-linux-arm64-gnu": ["@yuku-parser/binding-linux-arm64-gnu@0.6.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sRCtDktUgIbbV78SYX3wdGVVm1Hz/nSUS24JgXB4MzUeGNwBNB+eQAWMtBxCGriyJNXK3zwfj+SSgvTmUdPf/A=="],
+    "@yuku-parser/binding-linux-arm64-gnu": ["@yuku-parser/binding-linux-arm64-gnu@0.8.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-8nB5BhVz1lriSFi2H4zUERtpwKljVbGi2BKNT+QoHCspkFCaWEs0C7iEwT2vuY3xC8yBmh79+PEZ5VsQnOEKXA=="],
 
-    "@yuku-parser/binding-linux-arm64-musl": ["@yuku-parser/binding-linux-arm64-musl@0.6.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-3J/jV3ROSqlhLyB/6i5EUHxjkom5i59iPvrtiAsnAjHzMsZJJPEke9LSaOsB0rf4MJFH9AmjvsK8gDahTjZy+A=="],
+    "@yuku-parser/binding-linux-arm64-musl": ["@yuku-parser/binding-linux-arm64-musl@0.8.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-WhW8rN3ZszHGenlEOLMygsNayiT/30Nnmr+xHT1lC9WzyVJ3dBQCkEXtOkg1o1Ne1XhvpHCpjvcCQcWazyv7tg=="],
 
-    "@yuku-parser/binding-linux-x64-gnu": ["@yuku-parser/binding-linux-x64-gnu@0.6.3", "", { "os": "linux", "cpu": "x64" }, "sha512-a5mPn/OMSq2Aa2i7eJXcc37Jtw0b89gDO2mDpXN769b06IirEiqOzLNNJd6R7R8DxoadHzY0nLFhYNChE+jyAg=="],
+    "@yuku-parser/binding-linux-x64-gnu": ["@yuku-parser/binding-linux-x64-gnu@0.8.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Mwwr02Qz5ooJsca767PvYj7tL22+tpAlOPcVREK88tAIaM8DXtQQQq5tKZfWw4rdEEUpN4RkDLuCeENctmE23A=="],
 
-    "@yuku-parser/binding-linux-x64-musl": ["@yuku-parser/binding-linux-x64-musl@0.6.3", "", { "os": "linux", "cpu": "x64" }, "sha512-kQSjfa6zdvotuXEGNKQ9vZZxE+lcEEbTUMSuvY/5+0crlwBCjEqrf9/W9ViFDoQAEt8WJiu/mtVNYkKAOkjLmA=="],
+    "@yuku-parser/binding-linux-x64-musl": ["@yuku-parser/binding-linux-x64-musl@0.8.2", "", { "os": "linux", "cpu": "x64" }, "sha512-j4leuc7pNI1MvNkqf0OiNjqrRUf51FvAL32JQNoW8C9Z/HxSdC7G8tagT6y90lRb7/P8ec08ZTbL9JfPr4T/cQ=="],
 
-    "@yuku-parser/binding-win32-arm64": ["@yuku-parser/binding-win32-arm64@0.6.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-ZawdN3R0YKr48BeXCpbax+WDWbgEG6nWyDosVeZasrT5TjgfF4XMP5SfuyMNvRJ4gbTitrcYHZkENSXZ9ncqcg=="],
+    "@yuku-parser/binding-win32-arm64": ["@yuku-parser/binding-win32-arm64@0.8.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Y0MKfARGhQUc0BIcZnTeRWzGUF9o/OrzMhbkJ8lKsOPExXSx+J8+A+UPqlc1iVLA/KkDMZe1drkAShuYE7M2Gg=="],
 
-    "@yuku-parser/binding-win32-x64": ["@yuku-parser/binding-win32-x64@0.6.3", "", { "os": "win32", "cpu": "x64" }, "sha512-NcqZwBXQhKyfC0Eb+yBxXQcPjZoUstD1Dbr3X4UlOD1QiYfnvAYRKCZJ6nQ6KQ5p30dGaKkQeBL4t3qQtDQNWA=="],
+    "@yuku-parser/binding-win32-x64": ["@yuku-parser/binding-win32-x64@0.8.2", "", { "os": "win32", "cpu": "x64" }, "sha512-OdZowyOekNJca4uOKyNBY+BaDG0Pa0biE5bxyY4HwToK/Gs/UMZ54E1MZuPVPfq9kzEH4roOZQQN1ulBajwgjQ=="],
 
-    "@yuku-toolchain/types": ["@yuku-toolchain/types@0.5.43", "", {}, "sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ=="],
+    "@yuku-toolchain/types": ["@yuku-toolchain/types@0.8.2", "", {}, "sha512-ODYjxmbajkNCaONqd7dfIsH+h2ddRiI4YsSuQXy1Sg0ZSTvOETcNz5EiEIOqVSLnHDs1+r+b2yuS9eOw3ChguA=="],
 
     "ansis": ["ansis@4.3.1", "", {}, "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA=="],
 
@@ -361,29 +363,29 @@
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
-    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
@@ -391,7 +393,7 @@
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
-    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
     "package-manager-detector": ["package-manager-detector@1.7.0", "", {}, "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ=="],
 
@@ -399,19 +401,19 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
-    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
-    "publint": ["publint@0.3.21", "", { "dependencies": { "@publint/pack": "^0.1.4", "package-manager-detector": "^1.6.0", "picocolors": "^1.1.1", "sade": "^1.8.1" }, "bin": { "publint": "src/cli.js" } }, "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ=="],
+    "publint": ["publint@0.3.22", "", { "dependencies": { "@publint/pack": "^0.1.6", "package-manager-detector": "^1.7.0", "picocolors": "^1.1.1", "sade": "^1.8.1" }, "bin": { "publint": "./src/cli.js" } }, "sha512-6Z/scsr5CA7APdwyF35EY88CqgDj1textWuY788DVTJYPCWVv/Wn9G6KmLnrVRnStgYcahqN4wCDLZGSbQJ69w=="],
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
-    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+    "rolldown": ["rolldown@1.2.1", "", { "dependencies": { "@oxc-project/types": "=0.142.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.1", "@rolldown/binding-darwin-arm64": "1.2.1", "@rolldown/binding-darwin-x64": "1.2.1", "@rolldown/binding-freebsd-x64": "1.2.1", "@rolldown/binding-linux-arm-gnueabihf": "1.2.1", "@rolldown/binding-linux-arm64-gnu": "1.2.1", "@rolldown/binding-linux-arm64-musl": "1.2.1", "@rolldown/binding-linux-ppc64-gnu": "1.2.1", "@rolldown/binding-linux-s390x-gnu": "1.2.1", "@rolldown/binding-linux-x64-gnu": "1.2.1", "@rolldown/binding-linux-x64-musl": "1.2.1", "@rolldown/binding-openharmony-arm64": "1.2.1", "@rolldown/binding-wasm32-wasi": "1.2.1", "@rolldown/binding-win32-arm64-msvc": "1.2.1", "@rolldown/binding-win32-x64-msvc": "1.2.1" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw=="],
 
-    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.27.9", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.3", "yuku-ast": "^0.1.7", "yuku-codegen": "^0.6.1", "yuku-parser": "^0.6.1" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": "*", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-d54yt65+ZF/Mk8H6P36As02PAMdaiWRSzVNtJRc1h7nCgUFjuRI4cN2DyTfJyfVpPH6pgy7/2D7YQH1/Rh75Yg=="],
+    "rolldown-plugin-dts": ["rolldown-plugin-dts@0.27.14", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.4", "yuku-ast": "^0.8.0", "yuku-codegen": "^0.8.0", "yuku-parser": "^0.8.0" }, "peerDependencies": { "@typescript/native-preview": "*", "@volar/typescript": "~2.4.0", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@typescript/native-preview", "@volar/typescript", "typescript", "vue-tsc"] }, "sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw=="],
 
-    "runner-run": ["runner-run@0.19.1", "", { "optionalDependencies": { "@runner-run/darwin-arm64": "0.19.1", "@runner-run/darwin-x64": "0.19.1", "@runner-run/freebsd-arm64": "0.19.1", "@runner-run/freebsd-x64": "0.19.1", "@runner-run/linux-arm64-gnu": "0.19.1", "@runner-run/linux-arm64-musl": "0.19.1", "@runner-run/linux-armv7-gnueabihf": "0.19.1", "@runner-run/linux-x64-gnu": "0.19.1", "@runner-run/linux-x64-musl": "0.19.1", "@runner-run/netbsd-x64": "0.19.1", "@runner-run/win32-arm64-msvc": "0.19.1", "@runner-run/win32-ia32-msvc": "0.19.1", "@runner-run/win32-x64-msvc": "0.19.1" }, "bin": { "run": "bin/run.cjs", "runner": "bin/runner.cjs", "runner-run": "bin/runner.cjs" } }, "sha512-QNBk/E96yf6NDesYiIFLV52BICvy2HKYlvm9roOjrZRvUcE7scjsOFQT/kKJn2wnu7v3rMZIlZI0/ThgKQrYoQ=="],
+    "runner-run": ["runner-run@0.24.0", "", { "dependencies": { "ansispeck": "^0.4.1" }, "optionalDependencies": { "@runner-run/android-arm64": "0.24.0", "@runner-run/darwin-arm64": "0.24.0", "@runner-run/darwin-x64": "0.24.0", "@runner-run/freebsd-arm64": "0.24.0", "@runner-run/freebsd-x64": "0.24.0", "@runner-run/linux-arm64-gnu": "0.24.0", "@runner-run/linux-arm64-musl": "0.24.0", "@runner-run/linux-armv7-gnueabihf": "0.24.0", "@runner-run/linux-x64-gnu": "0.24.0", "@runner-run/linux-x64-musl": "0.24.0", "@runner-run/netbsd-x64": "0.24.0", "@runner-run/win32-arm64-msvc": "0.24.0", "@runner-run/win32-ia32-msvc": "0.24.0", "@runner-run/win32-x64-msvc": "0.24.0" }, "bin": { "run": "bin/run.cjs", "runner": "bin/runner.cjs", "runner-run": "bin/runner.cjs" } }, "sha512-Vua1u2zqrHOilP/kT/8eVvMqS8XXnIxLtksswuQU8gnuOkUQwgyER7rCM8aY1nrxVAy/+c25qB2Pwy40X8n+Rw=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
@@ -431,7 +433,7 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
-    "tsdown": ["tsdown@0.22.7", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.3", "picomatch": "^4.0.5", "rolldown": "~1.1.5", "rolldown-plugin-dts": "^0.27.8", "semver": "^7.8.5", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.7", "@tsdown/exe": "0.22.7", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-4egbOzc9dxVv/QS+gDV75FIxDIjQQeOnXBlUuikyjmn0ozuc6FW11djJjEEo3vqkuJRygpnKHurnj+Iwftk4VA=="],
+    "tsdown": ["tsdown@0.22.14", "", { "dependencies": { "ansis": "^4.3.1", "cac": "^7.0.0", "defu": "^6.1.7", "empathic": "^2.0.1", "hookable": "^6.1.1", "import-without-cache": "^0.4.0", "obug": "^2.1.4", "picomatch": "^4.0.5", "rolldown": "~1.2.0", "rolldown-plugin-dts": "^0.27.13", "tinyexec": "^1.2.4", "tinyglobby": "^0.2.17", "tree-kill": "^1.2.2", "unconfig-core": "^7.5.0", "verkit": "^0.3.0" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.22.14", "@tsdown/exe": "0.22.14", "@vitejs/devtools": "*", "publint": "^0.3.8", "tsx": "*", "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0", "unplugin-unused": "^0.5.0", "unrun": "*" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@vitejs/devtools", "publint", "tsx", "typescript", "unplugin-unused", "unrun"], "bin": { "tsdown": "./dist/run.mjs" } }, "sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -447,15 +449,17 @@
 
     "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
 
-    "vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
+    "verkit": ["verkit@0.3.1", "", {}, "sha512-w2Eo8LSIIoW7qxNBzT7/17k+bh8plXo7G3dHjEIDqPlnluhzaxr9JX8F28VSYEtDvc1/a3WBDih6xNUZseebXg=="],
+
+    "vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
-    "yuku-ast": ["yuku-ast@0.1.7", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" } }, "sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA=="],
+    "yuku-ast": ["yuku-ast@0.8.2", "", { "dependencies": { "@yuku-toolchain/types": "^0.8.2" } }, "sha512-GIxDPIyxjAKmF7J2AwrMDt2oCn+PZ0i7e+CIrvt5Tf0LbBS+v/xdbaAF1sUwrbntDq4YqtF7l6OG0amg1qhxWA=="],
 
-    "yuku-codegen": ["yuku-codegen@0.6.3", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-codegen/binding-darwin-arm64": "0.6.3", "@yuku-codegen/binding-darwin-x64": "0.6.3", "@yuku-codegen/binding-freebsd-x64": "0.6.3", "@yuku-codegen/binding-linux-arm-gnu": "0.6.3", "@yuku-codegen/binding-linux-arm-musl": "0.6.3", "@yuku-codegen/binding-linux-arm64-gnu": "0.6.3", "@yuku-codegen/binding-linux-arm64-musl": "0.6.3", "@yuku-codegen/binding-linux-x64-gnu": "0.6.3", "@yuku-codegen/binding-linux-x64-musl": "0.6.3", "@yuku-codegen/binding-win32-arm64": "0.6.3", "@yuku-codegen/binding-win32-x64": "0.6.3" } }, "sha512-3c9H521tf1RRDu4cNUySfH01sKlALve4HKu2sITk33gLl5HhsvI6ngSuarpWxMPAiJEgqJc/HTvojWQRnYm9/g=="],
+    "yuku-codegen": ["yuku-codegen@0.8.2", "", { "dependencies": { "@yuku-toolchain/types": "^0.8.2" }, "optionalDependencies": { "@yuku-codegen/binding-darwin-arm64": "0.8.2", "@yuku-codegen/binding-darwin-x64": "0.8.2", "@yuku-codegen/binding-freebsd-x64": "0.8.2", "@yuku-codegen/binding-linux-arm-gnu": "0.8.2", "@yuku-codegen/binding-linux-arm-musl": "0.8.2", "@yuku-codegen/binding-linux-arm64-gnu": "0.8.2", "@yuku-codegen/binding-linux-arm64-musl": "0.8.2", "@yuku-codegen/binding-linux-x64-gnu": "0.8.2", "@yuku-codegen/binding-linux-x64-musl": "0.8.2", "@yuku-codegen/binding-win32-arm64": "0.8.2", "@yuku-codegen/binding-win32-x64": "0.8.2" } }, "sha512-gkogheUZ41wQv3NWOfE4rwKgqW9DhfX1Afw0gECsxTl7A0oN3LrTfjYP/Vx1sT9d4pqNroqpsCY38ba6zFit3Q=="],
 
-    "yuku-parser": ["yuku-parser@0.6.3", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-parser/binding-darwin-arm64": "0.6.3", "@yuku-parser/binding-darwin-x64": "0.6.3", "@yuku-parser/binding-freebsd-x64": "0.6.3", "@yuku-parser/binding-linux-arm-gnu": "0.6.3", "@yuku-parser/binding-linux-arm-musl": "0.6.3", "@yuku-parser/binding-linux-arm64-gnu": "0.6.3", "@yuku-parser/binding-linux-arm64-musl": "0.6.3", "@yuku-parser/binding-linux-x64-gnu": "0.6.3", "@yuku-parser/binding-linux-x64-musl": "0.6.3", "@yuku-parser/binding-win32-arm64": "0.6.3", "@yuku-parser/binding-win32-x64": "0.6.3" } }, "sha512-iI6uABvvup9mvv8Mcpz7Tp//gehQlvcSnX4A4/0bf9i6X3RVQDuVUZel8jdpljwlF7WrbKsvD19y55Mc6+sKZw=="],
+    "yuku-parser": ["yuku-parser@0.8.2", "", { "dependencies": { "@yuku-toolchain/types": "^0.8.2", "yuku-ast": "^0.8.2" }, "optionalDependencies": { "@yuku-parser/binding-darwin-arm64": "0.8.2", "@yuku-parser/binding-darwin-x64": "0.8.2", "@yuku-parser/binding-freebsd-x64": "0.8.2", "@yuku-parser/binding-linux-arm-gnu": "0.8.2", "@yuku-parser/binding-linux-arm-musl": "0.8.2", "@yuku-parser/binding-linux-arm64-gnu": "0.8.2", "@yuku-parser/binding-linux-arm64-musl": "0.8.2", "@yuku-parser/binding-linux-x64-gnu": "0.8.2", "@yuku-parser/binding-linux-x64-musl": "0.8.2", "@yuku-parser/binding-win32-arm64": "0.8.2", "@yuku-parser/binding-win32-x64": "0.8.2" } }, "sha512-VD94CjEoAwCRoJzO4S151dGMlR9l1ned1VLYjsUIPH/v9N/MIP8yZD8K/p3hYon3VfuuIfUNvl3E1Ujq+i4Blw=="],
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
         "sort-package-json": "^4.0.0",
         "tsdown": "^0.22",
         "typescript": ">=6,<7",
-        "unplugin-unused": "^0.5",
+        "unplugin-unused": "^0.6",
         "vite": "^8",
       },
     },
@@ -445,7 +445,7 @@
 
     "unplugin": ["unplugin@3.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.4", "webpack-virtual-modules": "^0.6.2" }, "peerDependencies": { "@farmfe/core": "*", "@rspack/core": "*", "bun-types-no-globals": "*", "esbuild": "*", "rolldown": "*", "rollup": "*", "unloader": "*", "vite": "*", "webpack": "*" }, "optionalPeers": ["@farmfe/core", "@rspack/core", "bun-types-no-globals", "esbuild", "rolldown", "rollup", "unloader", "vite", "webpack"] }, "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg=="],
 
-    "unplugin-unused": ["unplugin-unused@0.5.7", "", { "dependencies": { "empathic": "^2.0.0", "escape-string-regexp": "^5.0.0", "js-tokens": "^10.0.0", "unplugin": "^3.0.0" } }, "sha512-quvqrHs6mPhk1hjbGwMoypXfagveue+/22dtgDrEzc2K9485ZAsnVfq7iYIgv7FwooiRa6+HDaLWgK2IavN+2g=="],
+    "unplugin-unused": ["unplugin-unused@0.6.0", "", { "dependencies": { "empathic": "^2.0.1", "escape-string-regexp": "^5.0.0", "js-tokens": "^10.0.0", "unplugin": "^3.3.0" } }, "sha512-ov+8yoEs5lyCjK7AqSUmpLuyEhtHwKtNtc1PrpwJVCNQjv+Dins4+7e1+ej57yo8lfiW/zOr9FAEmNmjgU+hFQ=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@5.0.1", "", {}, "sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ=="],
 

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
 		"fflate": "0.8.2"
 	},
 	"dependencies": {
-		"ansispeck": "^0.1.2",
-		"dreamcli": "npm:@kjanat/dreamcli@^3.0.0-rc.9",
+		"ansispeck": "^0.4.1",
+		"dreamcli": "npm:@kjanat/dreamcli@^3.0.1",
 		"sharp": "^0.35"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"@typescript/native": "npm:typescript@^7",
 		"dprint": "^0.55.1",
 		"publint": "^0.3",
-		"runner-run": "^0.19.1",
+		"runner-run": "^0.24.0",
 		"sort-package-json": "^4.0.0",
 		"tsdown": "^0.22",
 		"typescript": ">=6,<7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-svg-to-ico",
-	"version": "4.1.0",
+	"version": "5.0.0",
 	"description": "Vite plugin that converts SVG to ICO during site build.",
 	"keywords": [
 		"vite-plugin",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 		"sort-package-json": "^4.0.0",
 		"tsdown": "^0.22",
 		"typescript": ">=6,<7",
-		"unplugin-unused": "^0.5",
+		"unplugin-unused": "^0.6",
 		"vite": "^8"
 	},
 	"packageManager": "bun@1.3.14",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ import { inject } from '#cli/commands/inject';
  * {@link generate} is the default command: the one-off "turn this image into a
  * favicon" case is what most invocations want, so it needs no subcommand.
  * `{ route: true }` keeps the explicit name dispatchable and listed in help,
- * so the shorthand is an extra surface rather than a replacement.
+ * so both spellings work.
  */
 export const app = cli('svg-to-ico')
 	.manifest({ from: import.meta.url })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -46,7 +46,7 @@
  * ```
  */
 
-import { blue } from 'ansispeck';
+import { blue } from 'ansispeck/safe';
 import { cli } from 'dreamcli';
 import { generate } from '#cli/commands/generate';
 import { inject } from '#cli/commands/inject';
@@ -63,7 +63,7 @@ import { inject } from '#cli/commands/inject';
 export const app = cli('svg-to-ico')
 	.manifest({ from: import.meta.url })
 	.links()
-	.description(`Generate ICO favicons and inject ${blue('<link>')} tags into HTML files`)
+	.description(`Generate ICO favicons and inject ${blue`<link>`} tags into HTML files`)
 	.default(generate, { route: true })
 	.command(inject)
 	.completions();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,10 +23,9 @@
  * ## Subcommands
  *
  * - `generate <input>` — rasterize an image to a multi-size ICO (and
- *   optionally per-size PNGs/ICOs + a copy of the source) on disk. Registered
- *   as the **default** command, so `svg-to-ico src/icon.svg` is shorthand for
- *   `svg-to-ico generate src/icon.svg`; the explicit name still routes and is
- *   listed in help.
+ *   optionally per-size PNGs/ICOs + a copy of the source) on disk. The default
+ *   command: `svg-to-ico public/icon.svg` and `svg-to-ico generate
+ *   public/icon.svg` are the same invocation.
  * - `inject <files...>` — rewrite existing HTML files: strip
  *   `<link rel="icon">`/`<link rel="shortcut icon">` tags, splice the
  *   configured favicon tag set before `</head>`, preserve `apple-touch-icon`.
@@ -36,8 +35,8 @@
  * # SvelteKit adapter-static, wired into package.json scripts:
  * #   "build": "vite build && svg-to-ico inject build/index.html build/404.html -s 16 -s 32 -s 48 --source favicon.svg"
  *
- * # Shorthand: no subcommand needed for the common case.
- * svg-to-ico src/icon.svg --out-dir build
+ * # Write public/favicon.ico beside the source:
+ * svg-to-ico public/icon.svg
  *
  * # Generate a 16/32/48 ICO + per-size PNGs alongside it:
  * svg-to-ico generate src/icon.svg --out-dir build -s 16 -s 32 -s 48 --emit-sizes png --emit-source
@@ -56,11 +55,10 @@ import { inject } from '#cli/commands/inject';
  * Top-level `svg-to-ico` CLI: bundles {@link generate} and {@link inject}
  * subcommands plus shell-completion generation.
  *
- * {@link generate} is registered as the routed default command — the one-off
- * "turn this SVG into a favicon" case is what most invocations want, and
- * requiring a subcommand for it turned a valid path into `Unknown command`.
- * `{ route: true }` keeps `svg-to-ico generate …` working and keeps the
- * command listed in help, so the shorthand adds a surface without hiding one.
+ * {@link generate} is the default command: the one-off "turn this image into a
+ * favicon" case is what most invocations want, so it needs no subcommand.
+ * `{ route: true }` keeps the explicit name dispatchable and listed in help,
+ * so the shorthand is an extra surface rather than a replacement.
  */
 export const app = cli('svg-to-ico')
 	.manifest({ from: import.meta.url })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,10 @@
  * ## Subcommands
  *
  * - `generate <input>` — rasterize an image to a multi-size ICO (and
- *   optionally per-size PNGs/ICOs + a copy of the source) on disk.
+ *   optionally per-size PNGs/ICOs + a copy of the source) on disk. Registered
+ *   as the **default** command, so `svg-to-ico src/icon.svg` is shorthand for
+ *   `svg-to-ico generate src/icon.svg`; the explicit name still routes and is
+ *   listed in help.
  * - `inject <files...>` — rewrite existing HTML files: strip
  *   `<link rel="icon">`/`<link rel="shortcut icon">` tags, splice the
  *   configured favicon tag set before `</head>`, preserve `apple-touch-icon`.
@@ -32,6 +35,9 @@
  * ```sh
  * # SvelteKit adapter-static, wired into package.json scripts:
  * #   "build": "vite build && svg-to-ico inject build/index.html build/404.html -s 16 -s 32 -s 48 --source favicon.svg"
+ *
+ * # Shorthand: no subcommand needed for the common case.
+ * svg-to-ico src/icon.svg --out-dir build
  *
  * # Generate a 16/32/48 ICO + per-size PNGs alongside it:
  * svg-to-ico generate src/icon.svg --out-dir build -s 16 -s 32 -s 48 --emit-sizes png --emit-source
@@ -49,12 +55,18 @@ import { inject } from '#cli/commands/inject';
 /**
  * Top-level `svg-to-ico` CLI: bundles {@link generate} and {@link inject}
  * subcommands plus shell-completion generation.
+ *
+ * {@link generate} is registered as the routed default command — the one-off
+ * "turn this SVG into a favicon" case is what most invocations want, and
+ * requiring a subcommand for it turned a valid path into `Unknown command`.
+ * `{ route: true }` keeps `svg-to-ico generate …` working and keeps the
+ * command listed in help, so the shorthand adds a surface without hiding one.
  */
 export const app = cli('svg-to-ico')
 	.manifest({ from: import.meta.url })
 	.links()
 	.description(`Generate ICO favicons and inject ${blue('<link>')} tags into HTML files`)
-	.command(generate)
+	.default(generate, { route: true })
 	.command(inject)
 	.completions();
 

--- a/src/cli/args/source.ts
+++ b/src/cli/args/source.ts
@@ -61,14 +61,12 @@ async function imagesIn(dir: string, limit = 3): Promise<string[]> {
 }
 
 /**
- * Fail before sharp does, naming the fix.
+ * Reject an unreadable source with a message that names the likely intended
+ * file, rather than letting `readFile` surface a bare `ENOENT`/`EISDIR`.
  *
- * `generate` reads a *source* image and writes the ICO, and the overwhelmingly
- * common mistake is handing it the ICO path it is supposed to create. Node's
- * raw `ENOENT`/`EISDIR` mention neither that distinction nor the file sitting
- * right next to the one that was typed, so the three reachable bad inputs — an
- * ICO source, a missing file, a directory — are mapped onto {@link CLIError}s
- * that point at the likely intended file.
+ * `generate` reads a *source* image and writes the ICO, and the common mistake
+ * is handing it the ICO path it is supposed to create — hence the three cases
+ * covered here: an ICO source, a missing file, a directory.
  *
  * `http(s)://` inputs are left alone; {@link loadInputBytes} already reports
  * fetch failures with URL and status.
@@ -83,12 +81,12 @@ export async function assertReadableSource(input: string): Promise<void> {
 	// that does not, and sharp cannot decode the format either way.
 	if (inputExtname(path) === '.ico') {
 		const twin = await sameStemSource(path);
-		throw new CLIError(`${shown} is an ICO — that is what generate writes, not what it reads`, {
+		throw new CLIError(`Cannot read ${shown}: ICO is an output format, not a source image`, {
 			code: 'INPUT_IS_ICO',
 			details,
 			suggest: twin === undefined
 				? `Pass the source image (e.g. icon.svg) and name the ICO with --output ${basename(path)}`
-				: `Did you mean '${twin}'? The ICO name comes from --output (default favicon.ico)`,
+				: `Did you mean '${twin}'? The ICO filename comes from --output (default favicon.ico)`,
 		});
 	}
 
@@ -112,7 +110,7 @@ export async function assertReadableSource(input: string): Promise<void> {
 
 	if (stats.isDirectory()) {
 		const [first] = await imagesIn(path, 1);
-		throw new CLIError(`Source image expected, but ${shown} is a directory`, {
+		throw new CLIError(`Cannot read ${shown}: it is a directory, not a source image`, {
 			code: 'INPUT_IS_DIRECTORY',
 			details,
 			suggest: first === undefined

--- a/src/cli/args/source.ts
+++ b/src/cli/args/source.ts
@@ -1,6 +1,9 @@
-import { resolve } from 'node:path';
-import { arg } from 'dreamcli';
-import { isHttpUrl, normalizeInput } from '#loadInput';
+import { readdir, stat } from 'node:fs/promises';
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from 'node:path';
+import { cwd } from 'node:process';
+import { arg, CLIError } from 'dreamcli';
+import { inputExtname, isHttpUrl, normalizeInput } from '#loadInput';
+import { SUPPORTED_EXTENSIONS } from '#types';
 
 /**
  * Source-input arg. Accepts filesystem paths (resolved to absolute),
@@ -12,3 +15,109 @@ export const source = () =>
 		const s = normalizeInput(String(raw));
 		return isHttpUrl(s) ? s : resolve(s);
 	});
+
+/** Source extensions in "most likely the favicon source" order, for did-you-mean hints. */
+const PREFERRED_EXTENSIONS = [...SUPPORTED_EXTENSIONS];
+
+/**
+ * Render `path` relative to the invocation directory when it lives inside it.
+ * A hint the user can paste back beats an absolute path they have to read.
+ */
+function display(path: string): string {
+	const rel = relative(cwd(), path);
+	return rel === '' || rel.startsWith('..') || isAbsolute(rel) ? path : rel;
+}
+
+/** Directory listing, or `[]` when the directory is missing or unreadable. */
+async function entriesOf(dir: string): Promise<string[]> {
+	try {
+		return await readdir(dir);
+	} catch {
+		return [];
+	}
+}
+
+/** Whether `name` carries an extension sharp can decode. */
+function isSupported(name: string): boolean {
+	return SUPPORTED_EXTENSIONS.has(extname(name).toLowerCase());
+}
+
+/**
+ * A supported image sharing `path`'s basename-without-extension, if one sits
+ * beside it — `public/favicon.ico` → `public/favicon.svg`. Whenever the input
+ * is wrong, the file that was meant is almost always this one.
+ */
+async function sameStemSource(path: string): Promise<string | undefined> {
+	const dir = dirname(path);
+	const stem = basename(path, extname(path));
+	const names = new Set(await entriesOf(dir));
+	const ext = PREFERRED_EXTENSIONS.find((candidate) => names.has(stem + candidate));
+	return ext === undefined ? undefined : display(join(dir, stem + ext));
+}
+
+/** Up to `limit` supported images inside `dir`, alphabetically. */
+async function imagesIn(dir: string, limit = 3): Promise<string[]> {
+	return (await entriesOf(dir)).filter(isSupported).sort().slice(0, limit);
+}
+
+/**
+ * Fail before sharp does, naming the fix.
+ *
+ * `generate` reads a *source* image and writes the ICO, and the overwhelmingly
+ * common mistake is handing it the ICO path it is supposed to create. Node's
+ * raw `ENOENT`/`EISDIR` mention neither that distinction nor the file sitting
+ * right next to the one that was typed, so the three reachable bad inputs — an
+ * ICO source, a missing file, a directory — are mapped onto {@link CLIError}s
+ * that point at the likely intended file.
+ *
+ * `http(s)://` inputs are left alone; {@link loadInputBytes} already reports
+ * fetch failures with URL and status.
+ */
+export async function assertReadableSource(input: string): Promise<void> {
+	if (isHttpUrl(input)) return;
+	const path = normalizeInput(input);
+	const shown = display(path);
+	const details = { input: path };
+
+	// Checked before existence: an ICO that *does* exist is just as wrong as one
+	// that does not, and sharp cannot decode the format either way.
+	if (inputExtname(path) === '.ico') {
+		const twin = await sameStemSource(path);
+		throw new CLIError(`${shown} is an ICO — that is what generate writes, not what it reads`, {
+			code: 'INPUT_IS_ICO',
+			details,
+			suggest: twin === undefined
+				? `Pass the source image (e.g. icon.svg) and name the ICO with --output ${basename(path)}`
+				: `Did you mean '${twin}'? The ICO name comes from --output (default favicon.ico)`,
+		});
+	}
+
+	let stats: Awaited<ReturnType<typeof stat>>;
+	try {
+		stats = await stat(path);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+		const twin = await sameStemSource(path);
+		const nearby = await imagesIn(dirname(path));
+		throw new CLIError(`Source image not found: ${shown}`, {
+			code: 'INPUT_NOT_FOUND',
+			details,
+			suggest: twin !== undefined
+				? `Did you mean '${twin}'?`
+				: nearby.length > 0
+				? `Images in ${display(dirname(path))}: ${nearby.join(', ')}`
+				: 'Check the path — <input> is the image to rasterize, not the ICO to create',
+		});
+	}
+
+	if (stats.isDirectory()) {
+		const [first] = await imagesIn(path, 1);
+		throw new CLIError(`Source image expected, but ${shown} is a directory`, {
+			code: 'INPUT_IS_DIRECTORY',
+			details,
+			suggest: first === undefined
+				? `No supported images in ${shown} — pass the image file itself`
+				: `Did you mean '${display(join(path, first))}'?`,
+		});
+	}
+}

--- a/src/cli/args/source.ts
+++ b/src/cli/args/source.ts
@@ -62,7 +62,7 @@ async function imagesIn(dir: string, limit = 3): Promise<string[]> {
 
 /**
  * Reject an unreadable source with a message that names the likely intended
- * file, rather than letting `readFile` surface a bare `ENOENT`/`EISDIR`.
+ * file. Left alone, `readFile` surfaces a bare `ENOENT`/`EISDIR`.
  *
  * `generate` reads a *source* image and writes the ICO, and the common mistake
  * is handing it the ICO path it is supposed to create — hence the three cases
@@ -77,8 +77,7 @@ export async function assertReadableSource(input: string): Promise<void> {
 	const shown = display(path);
 	const details = { input: path };
 
-	// Checked before existence: an ICO that *does* exist is just as wrong as one
-	// that does not, and sharp cannot decode the format either way.
+	// Before the existence check: sharp cannot decode ICO whether it exists or not.
 	if (inputExtname(path) === '.ico') {
 		const twin = await sameStemSource(path);
 		throw new CLIError(`Cannot read ${shown}: ICO is an output format, not a source image`, {

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { blue, green, red } from 'ansispeck';
 import { command, flag } from 'dreamcli';
-import { source } from '#cli/args/source';
+import { assertReadableSource, source } from '#cli/args/source';
 import { sizesFlag } from '#cli/flags/sizes';
 import { packIco } from '#ico';
 import { inputBasename, loadInputBytes } from '#loadInput';
@@ -42,6 +42,7 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 		'output',
 		flag
 			.string()
+			.nonEmpty()
 			.alias('o')
 			.default('favicon.ico')
 			.describe(
@@ -84,20 +85,24 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 		flag
 			.boolean()
 			.default(true)
+			.negatable()
 			.describe(
-				`Apply max PNG compression (level 9 + adaptive filtering). Disable with ${blue('--optimize')}=${
-					red('false')
+				`Apply max PNG compression (level 9 + adaptive filtering). Disable with ${
+					blue('--no-optimize')
 				} for faster builds at the cost of larger files.`,
 			),
 	)
-	.example(green('generate src/icon.svg'), 'Write favicon.ico (16/32/48) to the current directory.')
 	.example(
-		green('generate src/icon.svg -d build -s16 -s32 -s48 --emit-sizes png --emit-source'),
-		'Generate ICO + per-size PNGs + copy of source into build/.',
+		(meta) => green(`${meta.name} src/icon.svg`),
+		'Shorthand — no subcommand needed. Writes favicon.ico (16/32/48) to the current directory',
 	)
 	.example(
-		green('generate src/icon.png -s64 -s128 -s256 -o icons/favicon.ico'),
-		'PNG input, custom sizes, nested output path.',
+		(meta) => green(`${meta.name} generate src/icon.svg -d build -s16 -s32 -s48 --emit-sizes png --emit-source`),
+		'Generate ICO + per-size PNGs + copy of source into build/',
+	)
+	.example(
+		(meta) => green(`${meta.name} generate src/icon.png -s64 -s128 -s256 -o icons/favicon.ico`),
+		'PNG input, custom sizes, nested output path',
 	)
 	.action(async ({ args, flags, out }) => {
 		const sizes = flags.sizes;
@@ -106,6 +111,7 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 		const outputStem = flags.output.replace(/\.ico$/i, '');
 		const { color: c } = out;
 
+		await assertReadableSource(input);
 		const inputBuffer = await loadInputBytes(input);
 		const pngs = await generateSizedPngs(inputBuffer, {
 			sizes,
@@ -115,11 +121,17 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 
 		await mkdir(outDir, { recursive: true });
 
+		/** Every path written, in write order — the payload behind `--json`. */
+		const written: string[] = [];
+
 		async function writeAt(targetPath: string, data: Buffer | string, detail?: string) {
 			await mkdir(dirname(targetPath), { recursive: true });
 			await writeFile(targetPath, data);
+			written.push(targetPath);
+			// A status line, not a log line: these are progress notes, so stdout
+			// stays clean for piping and `--quiet` actually silences them.
 			const linkedPath = c.link(pathToFileURL(targetPath), c.cyan(targetPath));
-			out.log(`${c.green('Wrote')} ${linkedPath}${detail ? ` ${c.dim(detail)}` : ''}`);
+			out.status(`${c.green('Wrote')} ${linkedPath}${detail ? ` ${c.dim(detail)}` : ''}`);
 		}
 
 		const icoPath = resolve(outDir, flags.output);
@@ -147,4 +159,6 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 				}
 			}
 		}
+
+		if (out.jsonMode) out.json({ input, ico: icoPath, sizes, bytes: icoBuffer.length, files: written });
 	});

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { cwd } from 'node:process';
 import { pathToFileURL } from 'node:url';
-import { blue, green, red } from 'ansispeck';
+import { blue, green, red } from 'ansispeck/safe';
 import { CLIError, command, flag } from 'dreamcli';
 import { assertReadableSource, source } from '#cli/args/source';
 import { DEFAULT_ICO_FILENAME, outputFlag } from '#cli/flags/output';
@@ -24,20 +24,17 @@ export const generate = command('generate')
 		`\
 Rasterize a source image into a multi-size ICO favicon. \
 Optionally also emit per-size PNG/ICO files and a copy of the original source. \
-Equivalent to what the Vite plugin emits during ${blue('vite build')}, but runs standalone.`,
+Equivalent to what the Vite plugin emits during ${blue`vite build`}, but runs standalone.`,
 	)
 	.arg(
 		'input',
 		source().describe(
 			`\
-Path, ${red('file://')} URL, or ${red('http(s)://')} URL to source image. \
-Paths and ${red('file://')} URLs are resolved to absolute; \
-${red('http(s)://')} URLs are fetched at run time. \
-Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${blue('.jpg')}/${blue('.jpeg')}, ${
-				blue(
-					'.webp',
-				)
-			}, ${blue('.avif')}, ${blue('.gif')}, ${blue('.tif')}/${blue('.tiff')}.`,
+Path, ${red`file://`} URL, or ${red`http(s)://`} URL to source image. \
+Paths and ${red`file://`} URLs are resolved to absolute; \
+${red`http(s)://`} URLs are fetched at run time. \
+Sharp-supported formats: ${blue`.svg`}, ${blue`.svgz`}, ${blue`.png`}, ${blue`.jpg`}/${blue`.jpeg`}, \
+${blue`.webp`}, ${blue`.avif`}, ${blue`.gif`}, ${blue`.tif`}/${blue`.tiff`}.`,
 		),
 	)
 	.flag(
@@ -45,9 +42,8 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 		// The `(default: …)` suffix is hand-written because the flag carries no
 		// `.default()`; see kjanat/dreamcli#88 and #89.
 		outputFlag().describe(
-			`Filename for the combined ICO (relative to ${
-				blue('--out-dir')
-			}). May include subdirectories; they are created as needed. (default: ${DEFAULT_ICO_FILENAME})`,
+			`Filename for the combined ICO (relative to ${blue`--out-dir`}). \
+May include subdirectories; they are created as needed. (default: ${DEFAULT_ICO_FILENAME})`,
 		),
 	)
 	.flag(
@@ -57,13 +53,10 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			.default(false)
 			.negatable()
 			.describe(
-				`Name the ICO after the source image — ${blue('icon.svg')} yields ${blue('icon.ico')} instead of ${
-					blue(DEFAULT_ICO_FILENAME)
-				}, and ${
-					blue('--emit-sizes')
-				} follows the same stem. Browsers only auto-request ${DEFAULT_ICO_FILENAME}, so a renamed ICO needs its own <link> tag. Conflicts with ${
-					blue('--output')
-				}; use ${blue('--no-keep-name')} to opt back out when a wrapper script presets it.`,
+				`Name the ICO after the source image — ${blue`icon.svg`} yields ${blue`icon.ico`} \
+instead of ${blue`${DEFAULT_ICO_FILENAME}`}, and ${blue`--emit-sizes`} follows the same stem. \
+Browsers only auto-request ${DEFAULT_ICO_FILENAME}, so a renamed ICO needs its own <link> tag. \
+Conflicts with ${blue`--output`}; use ${blue`--no-keep-name`} to opt back out when a wrapper script presets it.`,
 			),
 	)
 	.flag('sizes', sizesFlag())
@@ -73,9 +66,9 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			.path()
 			.alias('d')
 			.describe(
-				`Directory to write outputs into. Relative paths resolve from the current working directory. Created if missing. Defaults to the source image's own directory; ${
-					red('http(s)://')
-				} sources fall back to the current directory.`,
+				`Directory to write outputs into. Relative paths resolve from the current working directory. \
+Created if missing. Defaults to the source image's own directory; \
+${red`http(s)://`} sources fall back to the current directory.`,
 			),
 	)
 	.flag(
@@ -84,9 +77,8 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			.enum(['none', 'png', 'ico', 'both'])
 			.default('none')
 			.describe(
-				`Emit per-size files alongside the combined ICO: ${red('png')} (favicon-NxN.png), ${
-					red('ico')
-				} (favicon-NxN.ico), ${red('both')}, or ${red('none')}.`,
+				`Emit per-size files alongside the combined ICO: ${red`png`} (favicon-NxN.png), \
+${red`ico`} (favicon-NxN.ico), ${red`both`}, or ${red`none`}.`,
 			),
 	)
 	.flag(
@@ -94,7 +86,7 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 		flag
 			.boolean()
 			.default(false)
-			.describe(`Copy the original source image into ${blue('--out-dir')} (preserves its original basename).`),
+			.describe(`Copy the original source image into ${blue`--out-dir`} (preserves its original basename).`),
 	)
 	.flag(
 		'optimize',
@@ -107,15 +99,15 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			),
 	)
 	.example(
-		(meta) => green(`${meta.name} public/icon.svg`),
+		(meta) => green`${meta.name} public/icon.svg`,
 		'Write public/favicon.ico (16/32/48) beside the source',
 	)
 	.example(
-		(meta) => green(`${meta.name} generate src/icon.svg -d build -s16 -s32 -s48 --emit-sizes png --emit-source`),
+		(meta) => green`${meta.name} generate src/icon.svg -d build -s16 -s32 -s48 --emit-sizes png --emit-source`,
 		'Generate ICO + per-size PNGs + copy of source into build/',
 	)
 	.example(
-		(meta) => green(`${meta.name} generate src/icon.png -s64 -s128 -s256 -o icons/favicon.ico`),
+		(meta) => green`${meta.name} generate src/icon.png -s64 -s128 -s256 -o icons/favicon.ico`,
 		'PNG input, custom sizes, nested output path',
 	)
 	.action(async ({ args, flags, out }) => {

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from 'node:url';
 import { blue, green, red } from 'ansispeck';
 import { CLIError, command, flag } from 'dreamcli';
 import { assertReadableSource, source } from '#cli/args/source';
+import { DEFAULT_ICO_FILENAME, outputFlag } from '#cli/flags/output';
 import { sizesFlag } from '#cli/flags/sizes';
 import { packIco } from '#ico';
 import { inputBasename, inputStem, isHttpUrl, loadInputBytes } from '#loadInput';
@@ -41,17 +42,13 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 	)
 	.flag(
 		'output',
-		flag
-			.string()
-			.nonEmpty()
-			.alias('o')
-			.describe(
-				`Filename for the combined ICO (relative to ${
-					blue('--out-dir')
-				}). May include subdirectories; they are created as needed. Defaults to ${
-					blue('favicon.ico')
-				}, the name browsers request on their own.`,
-			),
+		outputFlag().describe(
+			`Filename for the combined ICO (relative to ${
+				blue('--out-dir')
+			}). May include subdirectories; they are created as needed. Defaults to ${
+				blue(DEFAULT_ICO_FILENAME)
+			}, the name browsers request on their own.`,
+		),
 	)
 	.flag(
 		'keep-name',
@@ -61,10 +58,10 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			.negatable()
 			.describe(
 				`Name the ICO after the source image — ${blue('icon.svg')} yields ${blue('icon.ico')} instead of ${
-					blue('favicon.ico')
+					blue(DEFAULT_ICO_FILENAME)
 				}, and ${
 					blue('--emit-sizes')
-				} follows the same stem. Browsers only auto-request favicon.ico, so a renamed ICO needs its own <link> tag. Conflicts with ${
+				} follows the same stem. Browsers only auto-request ${DEFAULT_ICO_FILENAME}, so a renamed ICO needs its own <link> tag. Conflicts with ${
 					blue('--output')
 				}; use ${blue('--no-keep-name')} to opt back out when a wrapper script presets it.`,
 			),
@@ -131,7 +128,7 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 				suggest: `Drop --keep-name to write '${flags.output}', or drop --output to derive the name from the source`,
 			});
 		}
-		const outputName = flags.output ?? (flags['keep-name'] ? `${inputStem(input)}.ico` : 'favicon.ico');
+		const outputName = flags.output ?? (flags['keep-name'] ? `${inputStem(input)}.ico` : DEFAULT_ICO_FILENAME);
 		const outputStem = outputName.replace(/\.ico$/i, '');
 		const { color: c } = out;
 

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -3,11 +3,11 @@ import { dirname, resolve } from 'node:path';
 import { cwd } from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { blue, green, red } from 'ansispeck';
-import { command, flag } from 'dreamcli';
+import { CLIError, command, flag } from 'dreamcli';
 import { assertReadableSource, source } from '#cli/args/source';
 import { sizesFlag } from '#cli/flags/sizes';
 import { packIco } from '#ico';
-import { inputBasename, isHttpUrl, loadInputBytes } from '#loadInput';
+import { inputBasename, inputStem, isHttpUrl, loadInputBytes } from '#loadInput';
 import { generateSizedPngs } from '#raster';
 
 /**
@@ -45,11 +45,28 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			.string()
 			.nonEmpty()
 			.alias('o')
-			.default('favicon.ico')
 			.describe(
 				`Filename for the combined ICO (relative to ${
 					blue('--out-dir')
-				}). May include subdirectories; they are created as needed.`,
+				}). May include subdirectories; they are created as needed. Defaults to ${
+					blue('favicon.ico')
+				}, the name browsers request on their own.`,
+			),
+	)
+	.flag(
+		'keep-name',
+		flag
+			.boolean()
+			.default(false)
+			.negatable()
+			.describe(
+				`Name the ICO after the source image — ${blue('icon.svg')} yields ${blue('icon.ico')} instead of ${
+					blue('favicon.ico')
+				}, and ${
+					blue('--emit-sizes')
+				} follows the same stem. Browsers only auto-request favicon.ico, so a renamed ICO needs its own <link> tag. Conflicts with ${
+					blue('--output')
+				}; use ${blue('--no-keep-name')} to opt back out when a wrapper script presets it.`,
 			),
 	)
 	.flag('sizes', sizesFlag())
@@ -111,7 +128,16 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 		// the shell happens to be in. Remote sources have no local directory to sit
 		// beside, so they fall back to the cwd.
 		const outDir = flags['out-dir'] ?? (isHttpUrl(input) ? cwd() : dirname(input));
-		const outputStem = flags.output.replace(/\.ico$/i, '');
+		// Two answers to the same question. A precedence rule here would be the
+		// kind nobody remembers, so say so instead of silently picking one.
+		if (flags.output !== undefined && flags['keep-name']) {
+			throw new CLIError('--output and --keep-name both name the ICO', {
+				code: 'OUTPUT_NAME_CONFLICT',
+				suggest: `Drop --keep-name to write '${flags.output}', or drop --output to derive the name from the source`,
+			});
+		}
+		const outputName = flags.output ?? (flags['keep-name'] ? `${inputStem(input)}.ico` : 'favicon.ico');
+		const outputStem = outputName.replace(/\.ico$/i, '');
 		const { color: c } = out;
 
 		await assertReadableSource(input);
@@ -137,7 +163,7 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			out.status(`${c.green('Wrote')} ${linkedPath}${detail ? ` ${c.dim(detail)}` : ''}`);
 		}
 
-		const icoPath = resolve(outDir, flags.output);
+		const icoPath = resolve(outDir, outputName);
 		await writeAt(
 			icoPath,
 			icoBuffer,

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -1,12 +1,13 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
+import { cwd } from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { blue, green, red } from 'ansispeck';
 import { command, flag } from 'dreamcli';
 import { assertReadableSource, source } from '#cli/args/source';
 import { sizesFlag } from '#cli/flags/sizes';
 import { packIco } from '#ico';
-import { inputBasename, loadInputBytes } from '#loadInput';
+import { inputBasename, isHttpUrl, loadInputBytes } from '#loadInput';
 import { generateSizedPngs } from '#raster';
 
 /**
@@ -57,9 +58,10 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 		flag
 			.path()
 			.alias('d')
-			.default('.')
 			.describe(
-				'Directory to write outputs into. Relative paths resolve from the current working directory. Created if missing. Defaults to the current working directory.',
+				`Directory to write outputs into. Relative paths resolve from the current working directory. Created if missing. Defaults to the source image's own directory, so ${
+					blue('generate public/icon.svg')
+				} writes ${blue('public/favicon.ico')}; ${red('http(s)://')} sources fall back to the current directory.`,
 			),
 	)
 	.flag(
@@ -93,8 +95,8 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			),
 	)
 	.example(
-		(meta) => green(`${meta.name} src/icon.svg`),
-		'Shorthand — no subcommand needed. Writes favicon.ico (16/32/48) to the current directory',
+		(meta) => green(`${meta.name} public/icon.svg`),
+		'Shorthand — no subcommand needed. Writes public/favicon.ico (16/32/48), beside the source',
 	)
 	.example(
 		(meta) => green(`${meta.name} generate src/icon.svg -d build -s16 -s32 -s48 --emit-sizes png --emit-source`),
@@ -107,7 +109,11 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 	.action(async ({ args, flags, out }) => {
 		const sizes = flags.sizes;
 		const input = args.input;
-		const outDir = flags['out-dir'];
+		// Unset --out-dir means "beside the source": `generate public/icon.svg` is
+		// asking for public/favicon.ico, not one in whatever directory the shell
+		// happens to be in. Remote sources have no local directory to sit beside,
+		// so they keep the cwd fallback.
+		const outDir = flags['out-dir'] ?? (isHttpUrl(input) ? cwd() : dirname(input));
 		const outputStem = flags.output.replace(/\.ico$/i, '');
 		const { color: c } = out;
 
@@ -143,7 +149,14 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 
 		if (flags['emit-source']) {
 			const sourcePath = resolve(outDir, inputBasename(input));
-			await writeAt(sourcePath, inputBuffer, '(source)');
+			// Writing beside the source makes the copy target the source itself.
+			// Rewriting a file with its own bytes gains nothing and risks truncating
+			// the original if the write is interrupted.
+			if (sourcePath === input) {
+				out.status(`${c.dim('Skipped')} ${c.cyan(sourcePath)} ${c.dim('(source copy is the source)')}`);
+			} else {
+				await writeAt(sourcePath, inputBuffer, '(source)');
+			}
 		}
 
 		const emitSizes = flags['emit-sizes'];

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -124,12 +124,7 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 	.action(async ({ args, flags, out }) => {
 		const sizes = flags.sizes;
 		const input = args.input;
-		// Outputs belong beside the image they came from, not in whatever directory
-		// the shell happens to be in. Remote sources have no local directory to sit
-		// beside, so they fall back to the cwd.
 		const outDir = flags['out-dir'] ?? (isHttpUrl(input) ? cwd() : dirname(input));
-		// Two answers to the same question. A precedence rule here would be the
-		// kind nobody remembers, so say so instead of silently picking one.
 		if (flags.output !== undefined && flags['keep-name']) {
 			throw new CLIError('--output and --keep-name both name the ICO', {
 				code: 'OUTPUT_NAME_CONFLICT',
@@ -150,15 +145,12 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 
 		await mkdir(outDir, { recursive: true });
 
-		/** Every path written, in write order — the payload behind `--json`. */
 		const written: string[] = [];
 
 		async function writeAt(targetPath: string, data: Buffer | string, detail?: string) {
 			await mkdir(dirname(targetPath), { recursive: true });
 			await writeFile(targetPath, data);
 			written.push(targetPath);
-			// status(), not log(): a progress note belongs on stderr so stdout stays
-			// pipeable, and it is what `--quiet` suppresses.
 			const linkedPath = c.link(pathToFileURL(targetPath), c.cyan(targetPath));
 			out.status(`${c.green('Wrote')} ${linkedPath}${detail ? ` ${c.dim(detail)}` : ''}`);
 		}
@@ -172,8 +164,6 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 
 		if (flags['emit-source']) {
 			const sourcePath = resolve(outDir, inputBasename(input));
-			// Rewriting the source with its own bytes gains nothing and risks
-			// truncating it if the write is interrupted.
 			if (sourcePath === input) {
 				out.status(`${c.dim('Skipped')} ${c.cyan(sourcePath)} ${c.dim('(source already in the output directory)')}`);
 			} else {

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from 'node:url';
 import { blue, green, red } from 'ansispeck/safe';
 import { CLIError, command, flag } from 'dreamcli';
 import { assertReadableSource, source } from '#cli/args/source';
-import { DEFAULT_ICO_FILENAME, outputFlag } from '#cli/flags/output';
+import { DEFAULT_ICO_FILENAME, icoStem, outputFlag } from '#cli/flags/output';
 import { sizesFlag } from '#cli/flags/sizes';
 import { packIco } from '#ico';
 import { inputBasename, inputStem, isHttpUrl, loadInputBytes } from '#loadInput';
@@ -121,7 +121,7 @@ ${red`ico`} (favicon-NxN.ico), ${red`both`}, or ${red`none`}.`,
 			});
 		}
 		const outputName = flags.output ?? (flags['keep-name'] ? `${inputStem(input)}.ico` : DEFAULT_ICO_FILENAME);
-		const outputStem = outputName.replace(/\.ico$/i, '');
+		const outputStem = icoStem(outputName);
 		const { color: c } = out;
 
 		await assertReadableSource(input);

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -59,9 +59,9 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			.path()
 			.alias('d')
 			.describe(
-				`Directory to write outputs into. Relative paths resolve from the current working directory. Created if missing. Defaults to the source image's own directory, so ${
-					blue('generate public/icon.svg')
-				} writes ${blue('public/favicon.ico')}; ${red('http(s)://')} sources fall back to the current directory.`,
+				`Directory to write outputs into. Relative paths resolve from the current working directory. Created if missing. Defaults to the source image's own directory; ${
+					red('http(s)://')
+				} sources fall back to the current directory.`,
 			),
 	)
 	.flag(
@@ -89,14 +89,12 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			.default(true)
 			.negatable()
 			.describe(
-				`Apply max PNG compression (level 9 + adaptive filtering). Disable with ${
-					blue('--no-optimize')
-				} for faster builds at the cost of larger files.`,
+				'Apply max PNG compression (level 9 + adaptive filtering). Disabling it builds faster at the cost of larger files.',
 			),
 	)
 	.example(
 		(meta) => green(`${meta.name} public/icon.svg`),
-		'Shorthand — no subcommand needed. Writes public/favicon.ico (16/32/48), beside the source',
+		'Write public/favicon.ico (16/32/48) beside the source',
 	)
 	.example(
 		(meta) => green(`${meta.name} generate src/icon.svg -d build -s16 -s32 -s48 --emit-sizes png --emit-source`),
@@ -109,10 +107,9 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 	.action(async ({ args, flags, out }) => {
 		const sizes = flags.sizes;
 		const input = args.input;
-		// Unset --out-dir means "beside the source": `generate public/icon.svg` is
-		// asking for public/favicon.ico, not one in whatever directory the shell
-		// happens to be in. Remote sources have no local directory to sit beside,
-		// so they keep the cwd fallback.
+		// Outputs belong beside the image they came from, not in whatever directory
+		// the shell happens to be in. Remote sources have no local directory to sit
+		// beside, so they fall back to the cwd.
 		const outDir = flags['out-dir'] ?? (isHttpUrl(input) ? cwd() : dirname(input));
 		const outputStem = flags.output.replace(/\.ico$/i, '');
 		const { color: c } = out;
@@ -134,8 +131,8 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 			await mkdir(dirname(targetPath), { recursive: true });
 			await writeFile(targetPath, data);
 			written.push(targetPath);
-			// A status line, not a log line: these are progress notes, so stdout
-			// stays clean for piping and `--quiet` actually silences them.
+			// status(), not log(): a progress note belongs on stderr so stdout stays
+			// pipeable, and it is what `--quiet` suppresses.
 			const linkedPath = c.link(pathToFileURL(targetPath), c.cyan(targetPath));
 			out.status(`${c.green('Wrote')} ${linkedPath}${detail ? ` ${c.dim(detail)}` : ''}`);
 		}
@@ -149,11 +146,10 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 
 		if (flags['emit-source']) {
 			const sourcePath = resolve(outDir, inputBasename(input));
-			// Writing beside the source makes the copy target the source itself.
-			// Rewriting a file with its own bytes gains nothing and risks truncating
-			// the original if the write is interrupted.
+			// Rewriting the source with its own bytes gains nothing and risks
+			// truncating it if the write is interrupted.
 			if (sourcePath === input) {
-				out.status(`${c.dim('Skipped')} ${c.cyan(sourcePath)} ${c.dim('(source copy is the source)')}`);
+				out.status(`${c.dim('Skipped')} ${c.cyan(sourcePath)} ${c.dim('(source already in the output directory)')}`);
 			} else {
 				await writeAt(sourcePath, inputBuffer, '(source)');
 			}

--- a/src/cli/commands/generate.ts
+++ b/src/cli/commands/generate.ts
@@ -42,12 +42,12 @@ Sharp-supported formats: ${blue('.svg')}, ${blue('.svgz')}, ${blue('.png')}, ${b
 	)
 	.flag(
 		'output',
+		// The `(default: …)` suffix is hand-written because the flag carries no
+		// `.default()`; see kjanat/dreamcli#88 and #89.
 		outputFlag().describe(
 			`Filename for the combined ICO (relative to ${
 				blue('--out-dir')
-			}). May include subdirectories; they are created as needed. Defaults to ${
-				blue(DEFAULT_ICO_FILENAME)
-			}, the name browsers request on their own.`,
+			}). May include subdirectories; they are created as needed. (default: ${DEFAULT_ICO_FILENAME})`,
 		),
 	)
 	.flag(

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { blue, green, red } from 'ansispeck/safe';
@@ -76,6 +76,17 @@ ${blue`<link rel="${red`icon`}" type="${red`image/svg+xml`}">`} tag is injected.
 			.describe(
 				`Format of ${blue`--source`} for the MIME type attribute. Only ${red`svg`} triggers the SVG \
 ${blue`<link>`}; other values are accepted but currently inert in tag generation.`,
+			),
+	)
+	.flag(
+		'generate-missing',
+		flag
+			.boolean()
+			.default(false)
+			.describe(
+				`Rasterize any referenced favicon that is not on disk from ${blue`--source`} and write it into \
+${blue`--asset-dir`}. Without this, a missing file is injected as an href anyway and 404s at run time. \
+Files already present are left alone.`,
 			),
 	)
 	.flag(
@@ -178,6 +189,41 @@ Defaults to each HTML file's own directory.`,
 			return undefined;
 		}
 
+		/** Targets already checked, so a multi-file run rasterizes each once. */
+		const ensured = new Set<string>();
+
+		/**
+		 * Write any referenced favicon that is missing from `assetDir`, rasterized
+		 * from `--source`. Unlike the embed path this leaves real files behind,
+		 * because the injected href points at them.
+		 */
+		async function writeMissingInto(assetDir: string) {
+			for (const inj of injections) {
+				if (inj.href.kind !== 'file') continue;
+				const path = resolve(assetDir, inj.href.filename);
+				if (ensured.has(path)) continue;
+				ensured.add(path);
+				if (await stat(path).then(() => true, () => false)) continue;
+
+				const bytes = await rasterizeFor(inj, assetDir);
+				if (!bytes) {
+					throw new CLIError(
+						`${c.red('inject --generate-missing:')} cannot produce "${inj.href.filename}"`,
+						{
+							code: 'GENERATE_MISSING',
+							details: { filename: inj.href.filename, source: sourceName },
+							suggest: sourceName === undefined
+								? 'Pass --source <image> to rasterize missing favicons from'
+								: `Check that "${sourceName}" exists in ${assetDir} and is a supported image`,
+						},
+					);
+				}
+				await mkdir(dirname(path), { recursive: true });
+				await writeFile(path, bytes);
+				status(`${c.green('Wrote')} ${c.link(pathToFileURL(path), c.cyan(path))} ${c.dim(`(from ${sourceName})`)}`);
+			}
+		}
+
 		/**
 		 * Read the favicon files an embed run needs (ICO, plus the SVG source if
 		 * set) from `assetDir`, returning a {@link TagContext} embed resolver that
@@ -232,7 +278,9 @@ Defaults to each HTML file's own directory.`,
 				}
 				throw e;
 			}
-			const embed = flags.embed ? await embedResolverFor(flags['asset-dir'] ?? dirname(abs)) : undefined;
+			const assetDir = flags['asset-dir'] ?? dirname(abs);
+			if (flags['generate-missing']) await writeMissingInto(assetDir);
+			const embed = flags.embed ? await embedResolverFor(assetDir) : undefined;
 			const tags = await buildFaviconTags(injections, { base: flags.base, embed });
 			const next = injectTagsIntoHtml(original, tags);
 			if (next !== original) {

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -169,6 +169,8 @@ ${blue`--generate-missing`} is set. Defaults to each HTML file's own directory.`
 		let rasterizeFailure: string | undefined;
 
 		async function rasterizeFor(inj: ResolvedInjection, assetDir: string): Promise<Buffer | undefined> {
+			// Cleared per attempt so a caller never reports an earlier target's failure.
+			rasterizeFailure = undefined;
 			if (sourceName === undefined) return undefined;
 			let sourceBytes: Buffer;
 			try {
@@ -215,7 +217,29 @@ ${blue`--generate-missing`} is set. Defaults to each HTML file's own directory.`
 				const path = resolve(assetDir, inj.href.filename);
 				if (ensured.has(path)) continue;
 				ensured.add(path);
-				if (await stat(path).then(() => true, () => false)) continue;
+
+				// Only a regular file counts as already present. A directory sitting on
+				// the path would otherwise be taken for the favicon and injected as a
+				// dead href, and a stat failure other than ENOENT is not "missing".
+				const filename = inj.href.filename;
+				const existing = await stat(path).catch((e: NodeJS.ErrnoException) => {
+					if (e.code === 'ENOENT') return undefined;
+					throw new CLIError(
+						`${c.red('inject --generate-missing:')} cannot inspect "${filename}": ${e.message}`,
+						{ code: 'GENERATE_MISSING', details: { filename, path } },
+					);
+				});
+				if (existing?.isFile()) continue;
+				if (existing !== undefined) {
+					throw new CLIError(
+						`${c.red('inject --generate-missing:')} "${filename}" exists but is not a regular file`,
+						{
+							code: 'GENERATE_MISSING',
+							details: { filename, path },
+							suggest: `Remove ${path}, or point --output elsewhere`,
+						},
+					);
+				}
 
 				const bytes = await rasterizeFor(inj, assetDir);
 				if (!bytes) {

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -3,8 +3,8 @@ import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { blue, green, red } from 'ansispeck/safe';
 import { arg, CLIError, command, flag } from 'dreamcli';
-import { DEFAULT_ICO_FILENAME, outputFlag } from '#cli/flags/output';
-import { sizesFlag } from '#cli/flags/sizes';
+import { DEFAULT_ICO_FILENAME, icoStem, outputFlag } from '#cli/flags/output';
+import { pngSizesFlag, sizesFlag } from '#cli/flags/sizes';
 import { toDataUri } from '#dataUri';
 import { buildFaviconTags, type TagContext } from '#faviconTags';
 import { injectTagsIntoHtml } from '#injectHtml';
@@ -47,6 +47,7 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			),
 	)
 	.flag('sizes', sizesFlag())
+	.flag('png-sizes', pngSizesFlag())
 	.flag(
 		'base',
 		flag
@@ -127,7 +128,18 @@ Defaults to each HTML file's own directory.`,
 			throw new CLIError('At least one HTML file path is required', { code: 'MISSING_FILES' });
 		}
 		const sourceName = flags.source;
+		const pngSizes = flags['png-sizes'];
 		const specs: EmitSpec[] = [{ format: 'ico', sizes: flags.sizes, filename: flags.output, inject: true }];
+		if (pngSizes.length > 0) {
+			specs.push({
+				format: 'png',
+				sizes: pngSizes,
+				// Same stem generate hangs its per-size files off, so a custom
+				// --output keeps both sides pointing at one filename.
+				filenameTemplate: `${icoStem(flags.output)}-{size}x{size}.png`,
+				inject: true,
+			});
+		}
 		if (sourceName) specs.push({ format: 'svg', filename: sourceName, inject: true });
 		const { injections } = resolveSpecs(specs, { inputFormat: flags['input-format'] });
 

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { blue, green, red } from 'ansispeck';
 import { arg, CLIError, command, flag } from 'dreamcli';
+import { DEFAULT_ICO_FILENAME, outputFlag } from '#cli/flags/output';
 import { sizesFlag } from '#cli/flags/sizes';
 import { toDataUri } from '#dataUri';
 import { buildFaviconTags, type TagContext } from '#faviconTags';
@@ -39,11 +40,8 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 	)
 	.flag(
 		'output',
-		flag
-			.string()
-			.nonEmpty()
-			.alias('o')
-			.default('favicon.ico')
+		outputFlag()
+			.default(DEFAULT_ICO_FILENAME)
 			.describe(
 				`ICO filename referenced in the injected ${blue('<link>')} (matches ${blue('generate')}'s ${
 					blue('--output')

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -8,7 +8,7 @@ import { pngSizesFlag, sizesFlag } from '#cli/flags/sizes';
 import { toDataUri } from '#dataUri';
 import { buildFaviconTags, type TagContext } from '#faviconTags';
 import { injectTagsIntoHtml } from '#injectHtml';
-import { resolveSpecs } from '#resolveSpecs';
+import { type ResolvedInjection, resolveSpecs } from '#resolveSpecs';
 import type { EmitSpec } from '#types';
 import { DATA_URI_ENCODINGS } from '#types';
 
@@ -144,20 +144,63 @@ Defaults to each HTML file's own directory.`,
 		const { injections } = resolveSpecs(specs, { inputFormat: flags['input-format'] });
 
 		/**
+		 * Bytes for an embed target that is not on disk, rasterized from `--source`.
+		 *
+		 * Only reachable under `--embed`, where the href carries the image itself,
+		 * so nothing has to exist at the referenced path — the file the tag names
+		 * is never fetched. Returns `undefined` when there is no usable source,
+		 * leaving the caller to report the original read failure.
+		 *
+		 * `sharp` loads through a dynamic import so a plain `inject` run, which
+		 * rasterizes nothing, does not pay for the native module.
+		 */
+		async function rasterizeFor(inj: ResolvedInjection, assetDir: string): Promise<Buffer | undefined> {
+			if (sourceName === undefined) return undefined;
+			let sourceBytes: Buffer;
+			try {
+				sourceBytes = await readFile(resolve(assetDir, sourceName));
+			} catch {
+				return undefined;
+			}
+			if (inj.type === 'image/svg+xml') return sourceBytes;
+
+			const { generateSizedPngs } = await import('#raster');
+			if (inj.type === 'image/x-icon') {
+				const { packIco } = await import('#ico');
+				return packIco(await generateSizedPngs(sourceBytes, { sizes: flags.sizes, optimize: true }));
+			}
+			if (inj.type === 'image/png') {
+				const size = Number.parseInt(inj.sizes ?? '', 10);
+				if (!Number.isInteger(size)) return undefined;
+				const [png] = await generateSizedPngs(sourceBytes, { sizes: [size], optimize: true });
+				return png?.buffer;
+			}
+			return undefined;
+		}
+
+		/**
 		 * Read the favicon files an embed run needs (ICO, plus the SVG source if
 		 * set) from `assetDir`, returning a {@link TagContext} embed resolver that
-		 * inlines them by filename. Throws a clear error if a referenced file is missing.
+		 * inlines them by filename. Missing files fall back to {@link rasterizeFor};
+		 * anything still unresolved throws.
 		 */
 		async function embedResolverFor(assetDir: string): Promise<NonNullable<TagContext['embed']>> {
 			// Iterate injections: resolveSpecs() drops inert tags (an SVG source under
 			// `--input-format png`), and reading their files would fail for nothing.
-			const names = [...new Set(injections.flatMap((inj) => (inj.href.kind === 'file' ? [inj.href.filename] : [])))];
+			const byName = new Map<string, ResolvedInjection>();
+			for (const inj of injections) if (inj.href.kind === 'file') byName.set(inj.href.filename, inj);
 			const bytesByName = new Map<string, Buffer>();
-			for (const name of names) {
+			for (const [name, inj] of byName) {
 				const path = resolve(assetDir, name);
 				try {
 					bytesByName.set(name, await readFile(path));
 				} catch (e) {
+					const rasterized = await rasterizeFor(inj, assetDir);
+					if (rasterized) {
+						bytesByName.set(name, rasterized);
+						status(`${c.dim('Rasterized')} ${c.cyan(name)} ${c.dim(`from ${sourceName} (not on disk)`)}`);
+						continue;
+					}
 					const linkedPath = c.link(pathToFileURL(path), c.cyan(path));
 					throw new CLIError(
 						`${c.red('inject --embed:')} cannot read "${name}" at ${linkedPath}: ${(e as Error).message}`,

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { blue, green, red } from 'ansispeck';
+import { blue, green, red } from 'ansispeck/safe';
 import { arg, CLIError, command, flag } from 'dreamcli';
 import { DEFAULT_ICO_FILENAME, outputFlag } from '#cli/flags/output';
 import { sizesFlag } from '#cli/flags/sizes';
@@ -23,10 +23,9 @@ export const inject = command('inject')
 	.description(
 		`\
 Rewrite existing HTML files on disk: \
-strip ${blue('<link rel="') + red('icon') + blue('">')} and ${
-			blue('<link rel="') + red('shortcut icon') + blue('">')
-		} tags (preserves ${red('apple-touch-icon')}), \
-splice in the configured favicon tag set before ${blue('</head>')}, and write back. \
+strip ${blue`<link rel="${red`icon`}">`} and ${blue`<link rel="${red`shortcut icon`}">`} \
+tags (preserves ${red`apple-touch-icon`}), \
+splice in the configured favicon tag set before ${blue`</head>`}, and write back. \
 The ICO/SVG files themselves are expected to already exist at the configured paths.`,
 	)
 	.arg(
@@ -43,9 +42,8 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 		outputFlag()
 			.default(DEFAULT_ICO_FILENAME)
 			.describe(
-				`ICO filename referenced in the injected ${blue('<link>')} (matches ${blue('generate')}'s ${
-					blue('--output')
-				}).`,
+				`ICO filename referenced in the injected ${blue`<link>`} \
+(matches ${blue`generate`}'s ${blue`--output`}).`,
 			),
 	)
 	.flag('sizes', sizesFlag())
@@ -55,9 +53,8 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			.string()
 			.default('/')
 			.describe(
-				`URL base prefix for hrefs (matches Vite's ${blue('base')} config). Trailing slash is optional; ${
-					blue('--base /app')
-				} and ${blue('--base /app/')} both yield ${red('/app/favicon.ico')}.`,
+				`URL base prefix for hrefs (matches Vite's ${blue`base`} config). Trailing slash is optional; \
+${blue`--base /app`} and ${blue`--base /app/`} both yield ${red`/app/${DEFAULT_ICO_FILENAME}`}.`,
 			),
 	)
 	.flag(
@@ -66,9 +63,8 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			.string()
 			.nonEmpty()
 			.describe(
-				`Filename of the source file (e.g. ${blue('favicon.svg')}). When set, an additional ${
-					blue('<link rel="') + red('icon') + blue('" type="') + red('image/svg+xml') + blue('">')
-				} tag is injected.`,
+				`Filename of the source file (e.g. ${blue`favicon.svg`}). When set, an additional \
+${blue`<link rel="${red`icon`}" type="${red`image/svg+xml`}">`} tag is injected.`,
 			),
 	)
 	.flag(
@@ -77,9 +73,8 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			.enum(['svg', 'png', 'jpg', 'webp', 'avif', 'gif', 'tiff'])
 			.default('svg')
 			.describe(
-				`Format of ${blue('--source')} for the MIME type attribute. Only ${red('svg')} triggers the SVG ${
-					blue('<link>')
-				}; other values are accepted but currently inert in tag generation.`,
+				`Format of ${blue`--source`} for the MIME type attribute. Only ${red`svg`} triggers the SVG \
+${blue`<link>`}; other values are accepted but currently inert in tag generation.`,
 			),
 	)
 	.flag(
@@ -88,9 +83,8 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			.boolean()
 			.default(false)
 			.describe(
-				`Inline the favicon bytes as ${blue('data:')} URIs instead of URL hrefs — the ${
-					blue('<link>')
-				} carries the image itself, no file reference. Reads the referenced files from ${blue('--asset-dir')}.`,
+				`Inline the favicon bytes as ${blue`data:`} URIs instead of URL hrefs — the ${blue`<link>`} \
+carries the image itself, no file reference. Reads the referenced files from ${blue`--asset-dir`}.`,
 			),
 	)
 	.flag(
@@ -99,33 +93,31 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			.enum(DATA_URI_ENCODINGS)
 			.default('base64')
 			.describe(
-				`Encoding for an embedded SVG ${blue('--source')}: ${red('base64')} or ${
-					red('utf8')
-				} (smaller, human-readable). Binary ICO is always ${red('base64')}. Only applies with ${blue('--embed')}.`,
+				`Encoding for an embedded SVG ${blue`--source`}: ${red`base64`} or ${red`utf8`} \
+(smaller, human-readable). Binary ICO is always ${red`base64`}. Only applies with ${blue`--embed`}.`,
 			),
 	)
 	.flag(
 		'asset-dir',
 		flag.path().describe(
-			`Directory to read favicon files from when ${
-				blue('--embed')
-			} is set. Defaults to each HTML file's own directory.`,
+			`Directory to read favicon files from when ${blue`--embed`} is set. \
+Defaults to each HTML file's own directory.`,
 		),
 	)
 	.example(
-		(meta) => green(`${meta.name} inject build/index.html`),
+		(meta) => green`${meta.name} inject build/index.html`,
 		'Inject default favicon.ico tag (16/32/48) into a single file',
 	)
 	.example(
-		(meta) => green(`${meta.name} inject build/index.html build/404.html -s16 -s32 -s48 --source favicon.svg`),
-		`Multi-file rewrite, also injects SVG source ${blue('<link>')}`,
+		(meta) => green`${meta.name} inject build/index.html build/404.html -s16 -s32 -s48 --source favicon.svg`,
+		`Multi-file rewrite, also injects SVG source ${blue`<link>`}`,
 	)
 	.example(
-		(meta) => green(`${meta.name} inject dist/index.html --base /repo/`),
+		(meta) => green`${meta.name} inject dist/index.html --base /repo/`,
 		'Inject under a subpath base (e.g. GitHub Pages project site)',
 	)
 	.example(
-		(meta) => green(`${meta.name} inject dist/index.html --source favicon.svg --embed --encoding utf8`),
+		(meta) => green`${meta.name} inject dist/index.html --source favicon.svg --embed --encoding utf8`,
 		'Inline the ICO + SVG straight into the HTML as data: URIs (no file references)',
 	)
 	.action(async ({ args, flags, out }) => {

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -112,8 +112,8 @@ carries the image itself, no file reference. Reads the referenced files from ${b
 	.flag(
 		'asset-dir',
 		flag.path().describe(
-			`Directory to read favicon files from when ${blue`--embed`} is set. \
-Defaults to each HTML file's own directory.`,
+			`Directory favicon files are read from when ${blue`--embed`} is set, and written to when \
+${blue`--generate-missing`} is set. Defaults to each HTML file's own directory.`,
 		),
 	)
 	.example(
@@ -165,6 +165,9 @@ Defaults to each HTML file's own directory.`,
 		 * `sharp` loads through a dynamic import so a plain `inject` run, which
 		 * rasterizes nothing, does not pay for the native module.
 		 */
+		/** Why the last rasterize attempt failed, carried into the caller's error details. */
+		let rasterizeFailure: string | undefined;
+
 		async function rasterizeFor(inj: ResolvedInjection, assetDir: string): Promise<Buffer | undefined> {
 			if (sourceName === undefined) return undefined;
 			let sourceBytes: Buffer;
@@ -175,22 +178,31 @@ Defaults to each HTML file's own directory.`,
 			}
 			if (inj.type === 'image/svg+xml') return sourceBytes;
 
-			const { generateSizedPngs } = await import('#raster');
-			if (inj.type === 'image/x-icon') {
-				const { packIco } = await import('#ico');
-				return packIco(await generateSizedPngs(sourceBytes, { sizes: flags.sizes, optimize: true }));
+			// A corrupt or unsupported source makes sharp throw. Catching here keeps
+			// the callers' diagnostics in play instead of surfacing a native error.
+			try {
+				const { generateSizedPngs } = await import('#raster');
+				if (inj.type === 'image/x-icon') {
+					const { packIco } = await import('#ico');
+					return packIco(await generateSizedPngs(sourceBytes, { sizes: flags.sizes, optimize: true }));
+				}
+				if (inj.type === 'image/png') {
+					const size = Number.parseInt(inj.sizes ?? '', 10);
+					if (!Number.isInteger(size)) return undefined;
+					const [png] = await generateSizedPngs(sourceBytes, { sizes: [size], optimize: true });
+					return png?.buffer;
+				}
+				return undefined;
+			} catch (e) {
+				rasterizeFailure = (e as Error).message;
+				return undefined;
 			}
-			if (inj.type === 'image/png') {
-				const size = Number.parseInt(inj.sizes ?? '', 10);
-				if (!Number.isInteger(size)) return undefined;
-				const [png] = await generateSizedPngs(sourceBytes, { sizes: [size], optimize: true });
-				return png?.buffer;
-			}
-			return undefined;
 		}
 
 		/** Targets already checked, so a multi-file run rasterizes each once. */
 		const ensured = new Set<string>();
+		/** Assets `--generate-missing` created, reported alongside the HTML results. */
+		const generated: string[] = [];
 
 		/**
 		 * Write any referenced favicon that is missing from `assetDir`, rasterized
@@ -211,7 +223,7 @@ Defaults to each HTML file's own directory.`,
 						`${c.red('inject --generate-missing:')} cannot produce "${inj.href.filename}"`,
 						{
 							code: 'GENERATE_MISSING',
-							details: { filename: inj.href.filename, source: sourceName },
+							details: { filename: inj.href.filename, source: sourceName, reason: rasterizeFailure },
 							suggest: sourceName === undefined
 								? 'Pass --source <image> to rasterize missing favicons from'
 								: `Check that "${sourceName}" exists in ${assetDir} and is a supported image`,
@@ -220,6 +232,7 @@ Defaults to each HTML file's own directory.`,
 				}
 				await mkdir(dirname(path), { recursive: true });
 				await writeFile(path, bytes);
+				generated.push(path);
 				status(`${c.green('Wrote')} ${c.link(pathToFileURL(path), c.cyan(path))} ${c.dim(`(from ${sourceName})`)}`);
 			}
 		}
@@ -250,7 +263,13 @@ Defaults to each HTML file's own directory.`,
 					const linkedPath = c.link(pathToFileURL(path), c.cyan(path));
 					throw new CLIError(
 						`${c.red('inject --embed:')} cannot read "${name}" at ${linkedPath}: ${(e as Error).message}`,
-						{ code: 'EMBED_READ' },
+						{
+							code: 'EMBED_READ',
+							details: { filename: name, source: sourceName, reason: rasterizeFailure },
+							...(rasterizeFailure === undefined
+								? {}
+								: { suggest: `Rasterizing from "${sourceName}" failed: ${rasterizeFailure}` }),
+						},
 					);
 				}
 			}
@@ -300,5 +319,5 @@ Defaults to each HTML file's own directory.`,
 			status(c.yellow('No files were modified.'));
 		}
 
-		if (out.jsonMode) out.json({ rewritten, files: results });
+		if (out.jsonMode) out.json({ rewritten, files: results, generated });
 	});

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -137,7 +137,6 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			throw new CLIError('At least one HTML file path is required', { code: 'MISSING_FILES' });
 		}
 		const sourceName = flags.source;
-		// Build the same spec model the plugin uses, then resolve to injections.
 		const specs: EmitSpec[] = [{ format: 'ico', sizes: flags.sizes, filename: flags.output, inject: true }];
 		if (sourceName) specs.push({ format: 'svg', filename: sourceName, inject: true });
 		const { injections } = resolveSpecs(specs, { inputFormat: flags['input-format'] });
@@ -148,10 +147,8 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 		 * inlines them by filename. Throws a clear error if a referenced file is missing.
 		 */
 		async function embedResolverFor(assetDir: string): Promise<NonNullable<TagContext['embed']>> {
-			// Read exactly the files the resolved injections reference — not whatever
-			// `--source` implies. resolveSpecs() may drop an inert tag (e.g. an SVG
-			// source under `--input-format png`), and reading its file would fail for
-			// no user-visible reason.
+			// Iterate injections: resolveSpecs() drops inert tags (an SVG source under
+			// `--input-format png`), and reading their files would fail for nothing.
 			const names = [...new Set(injections.flatMap((inj) => (inj.href.kind === 'file' ? [inj.href.filename] : [])))];
 			const bytesByName = new Map<string, Buffer>();
 			for (const name of names) {
@@ -174,7 +171,6 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			};
 		}
 
-		/** Per-file outcome, in argument order — the payload behind `--json`. */
 		const results: { file: string; status: 'rewritten' | 'unchanged' | 'missing' }[] = [];
 		let rewritten = 0;
 		for (const rel of files) {
@@ -191,7 +187,6 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 				}
 				throw e;
 			}
-			// Embedded hrefs read assets per file (default: the HTML's own directory).
 			const embed = flags.embed ? await embedResolverFor(flags['asset-dir'] ?? dirname(abs)) : undefined;
 			const tags = await buildFaviconTags(injections, { base: flags.base, embed });
 			const next = injectTagsIntoHtml(original, tags);

--- a/src/cli/commands/inject.ts
+++ b/src/cli/commands/inject.ts
@@ -41,6 +41,7 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 		'output',
 		flag
 			.string()
+			.nonEmpty()
 			.alias('o')
 			.default('favicon.ico')
 			.describe(
@@ -65,6 +66,7 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 		'source',
 		flag
 			.string()
+			.nonEmpty()
 			.describe(
 				`Filename of the source file (e.g. ${blue('favicon.svg')}). When set, an additional ${
 					blue('<link rel="') + red('icon') + blue('" type="') + red('image/svg+xml') + blue('">')
@@ -112,21 +114,24 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			} is set. Defaults to each HTML file's own directory.`,
 		),
 	)
-	.example(green('inject build/index.html'), 'Inject default favicon.ico tag (16/32/48) into a single file.')
 	.example(
-		green('inject build/index.html build/404.html -s16 -s32 -s48 --source favicon.svg'),
-		`Multi-file rewrite, also injects SVG source ${blue('<link>')}.`,
+		(meta) => green(`${meta.name} inject build/index.html`),
+		'Inject default favicon.ico tag (16/32/48) into a single file',
 	)
 	.example(
-		green('inject dist/index.html --base /repo/'),
-		'Inject under a subpath base (e.g. GitHub Pages project site).',
+		(meta) => green(`${meta.name} inject build/index.html build/404.html -s16 -s32 -s48 --source favicon.svg`),
+		`Multi-file rewrite, also injects SVG source ${blue('<link>')}`,
 	)
 	.example(
-		green('inject dist/index.html --source favicon.svg --embed --encoding utf8'),
-		'Inline the ICO + SVG straight into the HTML as data: URIs (no file references).',
+		(meta) => green(`${meta.name} inject dist/index.html --base /repo/`),
+		'Inject under a subpath base (e.g. GitHub Pages project site)',
+	)
+	.example(
+		(meta) => green(`${meta.name} inject dist/index.html --source favicon.svg --embed --encoding utf8`),
+		'Inline the ICO + SVG straight into the HTML as data: URIs (no file references)',
 	)
 	.action(async ({ args, flags, out }) => {
-		const { color: c, log, warn } = out;
+		const { color: c, status, warn } = out;
 		const files = args.files;
 		if (files.length === 0) {
 			throw new CLIError('At least one HTML file path is required', { code: 'MISSING_FILES' });
@@ -169,6 +174,8 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 			};
 		}
 
+		/** Per-file outcome, in argument order — the payload behind `--json`. */
+		const results: { file: string; status: 'rewritten' | 'unchanged' | 'missing' }[] = [];
 		let rewritten = 0;
 		for (const rel of files) {
 			const abs = resolve(rel);
@@ -179,6 +186,7 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 				if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
 					const linkedPath = c.link(pathToFileURL(abs), c.cyan(abs));
 					warn(`${c.yellow('inject:')} "${rel}" — file not found at ${linkedPath}, ${c.dim('skipping')}`);
+					results.push({ file: abs, status: 'missing' });
 					continue;
 				}
 				throw e;
@@ -192,13 +200,17 @@ The ICO/SVG files themselves are expected to already exist at the configured pat
 				await mkdir(dir, { recursive: true });
 				await writeFile(abs, next, 'utf8');
 				rewritten++;
-				log(`${c.green('Rewrote')} ${c.link(pathToFileURL(abs), c.cyan(rel))}`);
+				results.push({ file: abs, status: 'rewritten' });
+				status(`${c.green('Rewrote')} ${c.link(pathToFileURL(abs), c.cyan(rel))}`);
 			} else {
-				log(`${c.dim('Unchanged')} ${c.link(pathToFileURL(abs), c.cyan(rel))}`);
+				results.push({ file: abs, status: 'unchanged' });
+				status(`${c.dim('Unchanged')} ${c.link(pathToFileURL(abs), c.cyan(rel))}`);
 			}
 		}
 
 		if (rewritten === 0 && files.length > 0) {
-			log(c.yellow('No files were modified.'));
+			status(c.yellow('No files were modified.'));
 		}
+
+		if (out.jsonMode) out.json({ rewritten, files: results });
 	});

--- a/src/cli/flags/output.ts
+++ b/src/cli/flags/output.ts
@@ -16,3 +16,10 @@ export const DEFAULT_ICO_FILENAME = 'favicon.ico';
  * tell an explicit `-o` from `--keep-name`.
  */
 export const outputFlag = () => flag.string().nonEmpty().alias('o');
+
+/**
+ * Stem the per-size filenames hang off: `--output favicon.ico` gives
+ * `favicon-16x16.png`. `generate` writes those files and `inject` references
+ * them, so both derive the stem here to keep a custom `--output` in step.
+ */
+export const icoStem = (output: string) => output.replace(/\.ico$/i, '');

--- a/src/cli/flags/output.ts
+++ b/src/cli/flags/output.ts
@@ -1,0 +1,18 @@
+import { flag } from 'dreamcli';
+
+/**
+ * Filename both commands fall back to. Browsers request `/favicon.ico` without
+ * a `<link>` tag, so it is the one name that works with no HTML at all.
+ */
+export const DEFAULT_ICO_FILENAME = 'favicon.ico';
+
+/**
+ * Shared parse surface for `--output`/`-o`. `generate` writes the ICO and
+ * `inject` references it in the emitted `<link>`, so the two have to accept
+ * the same spellings and reject the same values.
+ *
+ * The default and the description stay with each command: `inject` always has
+ * a filename to point at, while `generate` leaves the flag unset so it can
+ * tell an explicit `-o` from `--keep-name`.
+ */
+export const outputFlag = () => flag.string().nonEmpty().alias('o');

--- a/src/cli/flags/sizes.ts
+++ b/src/cli/flags/sizes.ts
@@ -12,3 +12,18 @@ export const sizesFlag = () =>
 		.alias('s')
 		.default([16, 32, 48])
 		.describe(`Pixel sizes (integers 1–256). Pass repeated: ${blue`-s16 -s32 -s48`}.`);
+
+/**
+ * Build the `--png-sizes` flag: which standalone PNGs get their own
+ * `<link rel="icon" type="image/png">`. Standalone PNGs are not bound by ICO's
+ * 8-bit width/height field, so the ceiling is 4096 rather than 256. Empty means
+ * no PNG tags.
+ */
+export const pngSizesFlag = () =>
+	flag
+		.array(flag.number({ int: true, min: 1, max: 4096 }))
+		.default([])
+		.describe(
+			`Sizes (integers 1–4096) to emit a per-size PNG ${blue`<link>`} for, matching the files \
+${blue`generate --emit-sizes png`} writes. Pass repeated: ${blue`--png-sizes 192 --png-sizes 512`}.`,
+		);

--- a/src/cli/flags/sizes.ts
+++ b/src/cli/flags/sizes.ts
@@ -1,4 +1,4 @@
-import { blue } from 'ansispeck';
+import { blue } from 'ansispeck/safe';
 import { flag } from 'dreamcli';
 
 /**
@@ -11,4 +11,4 @@ export const sizesFlag = () =>
 		.array(flag.number({ int: true, min: 1, max: 256 }))
 		.alias('s')
 		.default([16, 32, 48])
-		.describe(`Pixel sizes (integers 1–256). Pass repeated: ${blue('-s16 -s32 -s48')}.`);
+		.describe(`Pixel sizes (integers 1–256). Pass repeated: ${blue`-s16 -s32 -s48`}.`);

--- a/src/inject-html.ts
+++ b/src/inject-html.ts
@@ -26,20 +26,54 @@ export function renderTag(tag: HtmlTagDescriptor): string {
 	return `${open}${children}</${tag.tag}>`;
 }
 
+/** Leading whitespace of `line`, or `undefined` when the line is blank. */
+function indentOf(line: string): string | undefined {
+	if (line.trim() === '') return undefined;
+	return /^[ \t]*/.exec(line)?.[0] ?? '';
+}
+
+/**
+ * Indentation to give injected tags, copied from the last populated line inside
+ * `<head>`. Falls back to one step past the closing tag's own indent, in the
+ * document's own whitespace character.
+ */
+function siblingIndent(head: string, closeIndent: string): string {
+	const open = /<head\b[^>]*>/i.exec(head);
+	const body = open ? head.slice(open.index + open[0].length) : head;
+	for (const line of body.split(/\r?\n/).reverse()) {
+		const indent = indentOf(line);
+		if (indent !== undefined) return indent;
+	}
+	return closeIndent + (closeIndent.includes('\t') ? '\t' : '  ');
+}
+
 /**
  * Inject favicon `<link>` tags into an HTML document string.
  *
  * Strips any existing `icon` / `shortcut icon` links (preserving `apple-touch-icon`)
  * and inserts the new tags before `</head>`. If no `</head>` is present, tags are
  * appended at the end of the document.
+ *
+ * Whitespace is copied from the document rather than imposed: tags take the
+ * indentation of the last populated line in `<head>`, `</head>` keeps its own,
+ * and the document's line ending is reused. A `</head>` that does not start its
+ * own line is treated as minified and gets no whitespace at all, so single-line
+ * documents stay single-line.
  */
 export function injectTagsIntoHtml(html: string, tags: HtmlTagDescriptor[]): string {
 	const cleaned = html.replace(INJECT_ICON_LINK_RE, '');
-	const rendered = tags.map(renderTag).join('\n    ');
-	const headCloseRe = /<\/head>/i;
-	const match = cleaned.match(headCloseRe);
-	if (match) {
-		return cleaned.replace(headCloseRe, `    ${rendered}\n  ${match[0]}`);
-	}
-	return `${cleaned}\n${rendered}`;
+	const match = /<\/head>/i.exec(cleaned);
+	if (!match) return `${cleaned}\n${tags.map(renderTag).join('\n')}`;
+
+	const before = cleaned.slice(0, match.index);
+	const lineStart = /(\r?\n)([ \t]*)$/.exec(before);
+	if (!lineStart) return `${before}${tags.map(renderTag).join('')}${cleaned.slice(match.index)}`;
+
+	const eol = lineStart[1] ?? '\n';
+	const closeIndent = lineStart[2] ?? '';
+	const tagIndent = siblingIndent(before, closeIndent);
+	const rendered = tags.map(renderTag).join(`${eol}${tagIndent}`);
+	return `${cleaned.slice(0, lineStart.index)}${eol}${tagIndent}${rendered}${eol}${closeIndent}${
+		cleaned.slice(match.index)
+	}`;
 }

--- a/src/load-input.ts
+++ b/src/load-input.ts
@@ -66,6 +66,12 @@ export function inputExtname(input: SourceInput): string {
 	return extname(inputBasename(input)).toLowerCase();
 }
 
+/** {@link inputBasename} stripped of its extension — `icon.svg` → `icon`. */
+export function inputStem(input: SourceInput): string {
+	const name = inputBasename(input);
+	return basename(name, extname(name));
+}
+
 /**
  * Read `input` bytes from disk or fetch them over http(s). `file://` URLs and
  * {@link URL} instances are accepted alongside plain strings.

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -646,6 +646,61 @@ describe('CLI', () => {
 			expect(result.stderr.join('')).toContain('must be <= 4096');
 		});
 
+		it('--generate-missing writes the referenced files it cannot find', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(
+				inject,
+				[file, '--source', 'favicon.svg', '--sizes', '16', '--png-sizes', '192', '--generate-missing'],
+			);
+			expect(result.exitCode).toBe(0);
+
+			expect((await Bun.file(join(dir, 'favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
+			const png = await Bun.file(join(dir, 'favicon-192x192.png')).bytes();
+			expect(png[0]).toBe(0x89); // PNG magic
+			expect(await Bun.file(file).text()).toContain('href="/favicon.ico"');
+		});
+
+		it('--generate-missing leaves files that already exist untouched', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), await Bun.file(FIXTURE).text());
+			const existing = Buffer.from([0, 0, 1, 0, 7, 7, 7]);
+			await Bun.write(join(dir, 'favicon.ico'), existing);
+
+			await runCommand(inject, [file, '--source', 'favicon.svg', '--generate-missing']);
+			expect(await Bun.file(join(dir, 'favicon.ico')).bytes()).toEqual(new Uint8Array(existing));
+		});
+
+		it('--generate-missing fails clearly with nothing to rasterize from', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+
+			const result = await runCommand(inject, [file, '--generate-missing']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('GENERATE_MISSING');
+			expect(result.error?.suggest).toContain('--source');
+		});
+
+		it('--generate-missing rasterizes once across several HTML files', async () => {
+			const dir = await setupTmp();
+			const a = join(dir, 'a.html');
+			const b = join(dir, 'b.html');
+			await Bun.write(a, '<head></head>');
+			await Bun.write(b, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(inject, [a, b, '--source', 'favicon.svg', '--generate-missing']);
+			expect(result.exitCode).toBe(0);
+			const wrote = result.stderr.join('\n').match(/Wrote .*favicon\.ico/g) ?? [];
+			expect(wrote).toHaveLength(1);
+		});
+
 		it('--embed rasterizes a missing target from --source without writing it', async () => {
 			const dir = await setupTmp();
 			const file = join(dir, 'index.html');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -94,7 +94,7 @@ describe('CLI', () => {
 
 			const result = await runCommand(generate, [svg, '--sizes', '16', '--emit-source']);
 			expect(result.exitCode).toBe(0);
-			expect(result.stderr.join('\n')).toContain('source copy is the source');
+			expect(result.stderr.join('\n')).toContain('source already in the output directory');
 			expect(await Bun.file(svg).text()).toBe(original);
 		});
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -570,6 +570,82 @@ describe('CLI', () => {
 			expect(result.stderr.join('')).toContain('cannot read');
 		});
 
+		it('--png-sizes links the per-size PNGs generate writes', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+
+			const result = await runCommand(inject, [file, '--sizes', '16', '--png-sizes', '192', '--png-sizes', '512']);
+			expect(result.exitCode).toBe(0);
+
+			const updated = await Bun.file(file).text();
+			expect(updated).toContain('<link rel="icon" type="image/png" href="/favicon-192x192.png" sizes="192x192">');
+			expect(updated).toContain('<link rel="icon" type="image/png" href="/favicon-512x512.png" sizes="512x512">');
+			// The combined ICO link survives alongside them.
+			expect(updated).toContain('href="/favicon.ico"');
+		});
+
+		it('emits no PNG links when --png-sizes is absent', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+
+			await runCommand(inject, [file]);
+			expect(await Bun.file(file).text()).not.toContain('image/png');
+		});
+
+		it('derives the PNG filenames from --output, matching generate', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'icon.svg'), await Bun.file(FIXTURE).text());
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+
+			const written = await runCommand(
+				generate,
+				[join(dir, 'icon.svg'), '-o', 'logo.ico', '--sizes', '16', '--emit-sizes', 'png'],
+			);
+			expect(written.exitCode).toBe(0);
+			expect(await Bun.file(join(dir, 'logo-16x16.png')).exists()).toBe(true);
+
+			await runCommand(inject, [file, '-o', 'logo.ico', '--sizes', '16', '--png-sizes', '16']);
+			expect(await Bun.file(file).text()).toContain('href="/logo-16x16.png"');
+		});
+
+		it('--png-sizes honors --base', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+
+			await runCommand(inject, [file, '--png-sizes', '192', '--base', '/repo/']);
+			expect(await Bun.file(file).text()).toContain('href="/repo/favicon-192x192.png"');
+		});
+
+		it('--png-sizes with --embed inlines the PNG instead of referencing it', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.ico'), Buffer.from([0, 0, 1, 0]));
+			const png = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+			await Bun.write(join(dir, 'favicon-192x192.png'), png);
+
+			const result = await runCommand(inject, [file, '--png-sizes', '192', '--embed']);
+			expect(result.exitCode).toBe(0);
+
+			const updated = await Bun.file(file).text();
+			expect(updated).toContain(`href="data:image/png;base64,${png.toString('base64')}"`);
+			expect(updated).not.toContain('href="/favicon-192x192.png"');
+		});
+
+		it('rejects a PNG size outside 1–4096', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+
+			const result = await runCommand(inject, [file, '--png-sizes', '8192']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stderr.join('')).toContain('must be <= 4096');
+		});
+
 		it('reports per-file outcomes on stdout under --json', async () => {
 			const dir = await setupTmp();
 			const file = join(dir, 'index.html');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -720,6 +720,21 @@ describe('CLI', () => {
 			expect(result.error?.suggest).toContain('unsupported image format');
 		});
 
+		it('--generate-missing refuses a target that is not a regular file', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), await Bun.file(FIXTURE).text());
+			// A directory on the target path would otherwise read as "already there".
+			await mkdir(join(dir, 'favicon.ico'), { recursive: true });
+
+			const result = await runCommand(inject, [file, '--source', 'favicon.svg', '--generate-missing']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('GENERATE_MISSING');
+			expect(result.error?.message).toContain('not a regular file');
+			expect(await Bun.file(file).text()).not.toContain('href=');
+		});
+
 		it('--generate-missing fails clearly with nothing to rasterize from', async () => {
 			const dir = await setupTmp();
 			const file = join(dir, 'index.html');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -73,6 +73,75 @@ describe('CLI', () => {
 			expect((await Bun.file(join(dir, 'icons/favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
 		});
 
+		it('names the ICO favicon.ico regardless of the source name by default', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'logo.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(generate, [join(dir, 'logo.svg'), '--sizes', '16']);
+			expect(result.exitCode).toBe(0);
+			expect(await Bun.file(join(dir, 'favicon.ico')).exists()).toBe(true);
+			expect(await Bun.file(join(dir, 'logo.ico')).exists()).toBe(false);
+		});
+
+		it('--keep-name names the ICO after the source, per-size files included', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'logo.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(
+				generate,
+				[join(dir, 'logo.svg'), '--sizes', '16', '--keep-name', '--emit-sizes', 'both'],
+			);
+			expect(result.exitCode).toBe(0);
+			expect((await Bun.file(join(dir, 'logo.ico')).bytes()).byteLength).toBeGreaterThan(0);
+			expect(await Bun.file(join(dir, 'logo-16x16.png')).exists()).toBe(true);
+			expect(await Bun.file(join(dir, 'logo-16x16.ico')).exists()).toBe(true);
+			expect(await Bun.file(join(dir, 'favicon.ico')).exists()).toBe(false);
+		});
+
+		it('--keep-name derives from a URL basename for remote sources', async () => {
+			const dir = await setupTmp();
+			const svgBytes = await Bun.file(FIXTURE).bytes();
+			const stub = makeFetchStub(async () => new Response(svgBytes, { status: 200 }));
+
+			const result = await withStubbedFetch(stub, () =>
+				runCommand(generate, [
+					'https://example.test/brand/mark.svg?v=2',
+					'--out-dir',
+					dir,
+					'--sizes',
+					'16',
+					'--keep-name',
+				]));
+			expect(result.exitCode).toBe(0);
+			expect((await Bun.file(join(dir, 'mark.ico')).bytes()).byteLength).toBeGreaterThan(0);
+		});
+
+		it('refuses --output and --keep-name together rather than picking one', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'logo.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(generate, [join(dir, 'logo.svg'), '--keep-name', '-o', 'custom.ico']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('OUTPUT_NAME_CONFLICT');
+			expect(result.error?.suggest).toContain('custom.ico');
+			expect(await Bun.file(join(dir, 'custom.ico')).exists()).toBe(false);
+			expect(await Bun.file(join(dir, 'logo.ico')).exists()).toBe(false);
+		});
+
+		it('--no-keep-name reopens --output for callers that preset --keep-name', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'logo.svg'), await Bun.file(FIXTURE).text());
+
+			// The shape a wrapper script produces: preset flags first, per-call override after.
+			const result = await runCommand(
+				generate,
+				[join(dir, 'logo.svg'), '--keep-name', '--sizes', '16', '--no-keep-name', '-o', 'custom.ico'],
+			);
+			expect(result.exitCode).toBe(0);
+			expect((await Bun.file(join(dir, 'custom.ico')).bytes()).byteLength).toBeGreaterThan(0);
+			expect(await Bun.file(join(dir, 'logo.ico')).exists()).toBe(false);
+		});
+
 		it('lets an explicit --out-dir win over the source directory', async () => {
 			const dir = await setupTmp();
 			const src = join(dir, 'src');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -45,8 +45,7 @@ describe('CLI', () => {
 			const help = result.stdout.join('\n');
 			const flatHelp = help.replace(/\s+/g, ' ');
 			expect(flatHelp).toContain("Defaults to the source image's own directory");
-			// The out-dir default is derived per input, so there is no resolved value
-			// to print — and never the absolute cwd of whoever rendered the help.
+			// Guards a past bug: the rendering machine's absolute cwd leaking into help.
 			expect(flatHelp).not.toContain('back to the current directory. (default:');
 			expect(help).not.toContain(cwd());
 		});
@@ -132,7 +131,6 @@ describe('CLI', () => {
 			const dir = await setupTmp();
 			await Bun.write(join(dir, 'logo.svg'), await Bun.file(FIXTURE).text());
 
-			// The shape a wrapper script produces: preset flags first, per-call override after.
 			const result = await runCommand(
 				generate,
 				[join(dir, 'logo.svg'), '--keep-name', '--sizes', '16', '--no-keep-name', '-o', 'custom.ico'],
@@ -195,7 +193,6 @@ describe('CLI', () => {
 			const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '16'], { out });
 			expect(result.exitCode).toBe(0);
 
-			// Progress notes are status lines: stderr, so stdout stays pipeable.
 			const rendered = stderr.join('');
 			expect(stdout.join('')).toBe('');
 			expect(rendered).toContain('\x1b[32mWrote\x1b[39m');
@@ -296,8 +293,6 @@ describe('CLI', () => {
 		it('falls back to the cwd for a remote source, which has no local directory', async () => {
 			const dir = await setupTmp();
 			const svgBytes = await Bun.file(FIXTURE).bytes();
-			// A real server, not a fetch stub: the CLI runs in a subprocess here, so
-			// the cwd it resolves against has to be a real one too.
 			const server = Bun.serve({
 				port: 0,
 				fetch: () => new Response(svgBytes, { headers: { 'content-type': 'image/svg+xml' } }),
@@ -344,7 +339,6 @@ describe('CLI', () => {
 			expect(result.exitCode).not.toBe(0);
 			expect(result.error?.code).toBe('INPUT_IS_ICO');
 			expect(result.error?.suggest).toContain(join(dir, 'favicon.svg'));
-			// The ICO is an output, and the flag that names it is the actionable part.
 			expect(result.error?.suggest).toContain('--output');
 		});
 
@@ -429,7 +423,6 @@ describe('CLI', () => {
 			const help = result.stdout.join('\n');
 			expect(help).toContain('generate (default)');
 			expect(help).toContain('inject');
-			// Examples resolve the real program name rather than hardcoding one.
 			expect(help).toContain('$ svg-to-ico public/icon.svg');
 		});
 
@@ -515,7 +508,6 @@ describe('CLI', () => {
 			expect(result.exitCode).toBe(0);
 			const all = [...result.stdout, ...result.stderr].join('\n');
 			expect(all).toContain('file not found');
-			// the present one still got rewritten
 			expect(await Bun.file(present).text()).toContain('/favicon.ico');
 		});
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -38,25 +38,64 @@ async function withStubbedFetch<T>(stub: typeof globalThis.fetch, fn: () => Prom
 
 describe('CLI', () => {
 	describe('generate', () => {
-		it('documents the default out dir as the current directory, not a captured absolute path', async () => {
+		it('documents the derived out dir without capturing an absolute path', async () => {
 			const result = await runCommand(generate, ['--help']);
 			expect(result.exitCode).toBe(0);
 
 			const help = result.stdout.join('\n');
 			const flatHelp = help.replace(/\s+/g, ' ');
-			expect(flatHelp).toContain('Defaults to the current working directory. (default: .)');
-			expect(help).toContain('(default: .)');
+			expect(flatHelp).toContain("Defaults to the source image's own directory");
+			// The out-dir default is derived per input, so there is no resolved value
+			// to print — and never the absolute cwd of whoever rendered the help.
+			expect(flatHelp).not.toContain('back to the current directory. (default:');
 			expect(help).not.toContain(cwd());
 		});
 
-		it('writes to the invocation cwd by default', async () => {
+		it('writes beside the source image by default, not into the invocation cwd', async () => {
 			const dir = await setupTmp();
-			const result = await Bun.$`bun ${CLI_ENTRY} generate ${FIXTURE} --sizes 16`.cwd(dir).quiet().nothrow();
+			const assets = join(dir, 'assets');
+			await mkdir(assets, { recursive: true });
+			await Bun.write(join(assets, 'icon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await Bun.$`bun ${CLI_ENTRY} generate assets/icon.svg --sizes 16`.cwd(dir).quiet().nothrow();
 			expect(result.exitCode).toBe(0);
 
-			const ico = await Bun.file(join(dir, 'favicon.ico')).bytes();
-			expect(ico.byteLength).toBeGreaterThan(0);
-			expect(await Bun.file(join(dir, 'public/favicon.ico')).exists()).toBe(false);
+			expect((await Bun.file(join(assets, 'favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
+			expect(await Bun.file(join(dir, 'favicon.ico')).exists()).toBe(false);
+		});
+
+		it('resolves --output subdirectories against the derived out dir', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'icon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(generate, [join(dir, 'icon.svg'), '--sizes', '16', '-o', 'icons/favicon.ico']);
+			expect(result.exitCode).toBe(0);
+			expect((await Bun.file(join(dir, 'icons/favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
+		});
+
+		it('lets an explicit --out-dir win over the source directory', async () => {
+			const dir = await setupTmp();
+			const src = join(dir, 'src');
+			const build = join(dir, 'build');
+			await mkdir(src, { recursive: true });
+			await Bun.write(join(src, 'icon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(generate, [join(src, 'icon.svg'), '--out-dir', build, '--sizes', '16']);
+			expect(result.exitCode).toBe(0);
+			expect((await Bun.file(join(build, 'favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
+			expect(await Bun.file(join(src, 'favicon.ico')).exists()).toBe(false);
+		});
+
+		it('skips the source copy when --emit-source would overwrite the source itself', async () => {
+			const dir = await setupTmp();
+			const svg = join(dir, 'icon.svg');
+			const original = await Bun.file(FIXTURE).text();
+			await Bun.write(svg, original);
+
+			const result = await runCommand(generate, [svg, '--sizes', '16', '--emit-source']);
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr.join('\n')).toContain('source copy is the source');
+			expect(await Bun.file(svg).text()).toBe(original);
 		});
 
 		it('writes a multi-size favicon.ico to the out dir', async () => {
@@ -185,6 +224,25 @@ describe('CLI', () => {
 			expect(sourceCopy).toContain('<svg');
 		});
 
+		it('falls back to the cwd for a remote source, which has no local directory', async () => {
+			const dir = await setupTmp();
+			const svgBytes = await Bun.file(FIXTURE).bytes();
+			// A real server, not a fetch stub: the CLI runs in a subprocess here, so
+			// the cwd it resolves against has to be a real one too.
+			const server = Bun.serve({
+				port: 0,
+				fetch: () => new Response(svgBytes, { headers: { 'content-type': 'image/svg+xml' } }),
+			});
+			try {
+				const url = `http://localhost:${server.port}/remote.svg`;
+				const result = await Bun.$`bun ${CLI_ENTRY} generate ${url} --sizes 16`.cwd(dir).quiet().nothrow();
+				expect(result.exitCode).toBe(0);
+				expect((await Bun.file(join(dir, 'favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
+			} finally {
+				await server.stop(true);
+			}
+		});
+
 		it('accepts a file:// URL string as input', async () => {
 			const dir = await setupTmp();
 			const fileUrl = Bun.pathToFileURL(FIXTURE).toString();
@@ -303,7 +361,7 @@ describe('CLI', () => {
 			expect(help).toContain('generate (default)');
 			expect(help).toContain('inject');
 			// Examples resolve the real program name rather than hardcoding one.
-			expect(help).toContain('$ svg-to-ico src/icon.svg');
+			expect(help).toContain('$ svg-to-ico public/icon.svg');
 		});
 
 		it('keeps suggesting a real command for a near-miss typo', async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { cwd } from 'node:process';
+import { strip } from 'ansispeck';
 import { createOutput } from 'dreamcli';
 import { runCommand } from 'dreamcli/testkit';
 import { app } from '#cli';
@@ -42,7 +43,7 @@ describe('CLI', () => {
 			const result = await runCommand(generate, ['--help']);
 			expect(result.exitCode).toBe(0);
 
-			const help = result.stdout.join('\n');
+			const help = strip(result.stdout.join('\n'));
 			const flatHelp = help.replace(/\s+/g, ' ');
 			expect(flatHelp).toContain("Defaults to the source image's own directory");
 			// Guards a past bug: the rendering machine's absolute cwd leaking into help.
@@ -420,7 +421,9 @@ describe('CLI', () => {
 			const result = await app.execute(['--help'], { help: { width: 200 } });
 			expect(result.exitCode).toBe(0);
 
-			const help = result.stdout.join('\n');
+			// Stripped: ansispeck enables colour whenever CI is set, so the raw help
+			// carries escapes on a runner and none locally.
+			const help = strip(result.stdout.join('\n'));
 			expect(help).toContain('generate (default)');
 			expect(help).toContain('inject');
 			expect(help).toContain('$ svg-to-ico public/icon.svg');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,6 +5,7 @@ import { join, resolve } from 'node:path';
 import { cwd } from 'node:process';
 import { createOutput } from 'dreamcli';
 import { runCommand } from 'dreamcli/testkit';
+import { app } from '#cli';
 import { inject } from '#cli/commands/inject';
 import { generate } from '#internals/cli/commands/generate.ts';
 
@@ -75,19 +76,55 @@ describe('CLI', () => {
 		it('uses DreamCLI colors and ansispeck hyperlinks when styling is enabled', async () => {
 			const dir = await setupTmp();
 			const stdout: string[] = [];
+			const stderr: string[] = [];
 			const out = createOutput({
 				color: true,
 				isTTY: true,
 				stdout: (value) => stdout.push(value),
+				stderr: (value) => stderr.push(value),
 			});
 
 			const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '16'], { out });
 			expect(result.exitCode).toBe(0);
 
-			const rendered = stdout.join('');
+			// Progress notes are status lines: stderr, so stdout stays pipeable.
+			const rendered = stderr.join('');
+			expect(stdout.join('')).toBe('');
 			expect(rendered).toContain('\x1b[32mWrote\x1b[39m');
 			expect(rendered).toContain('\x1b]8;;file://');
 			expect(rendered).toContain(`\x1b[36m${join(dir, 'favicon.ico')}\x1b[39m`);
+		});
+
+		it('silences progress notes under --quiet but still writes the ICO', async () => {
+			const dir = await setupTmp();
+			const result = await Bun.$`bun ${CLI_ENTRY} --quiet generate ${FIXTURE} --out-dir ${dir} --sizes 16`
+				.quiet()
+				.nothrow();
+			expect(result.exitCode).toBe(0);
+			expect(result.stdout.toString()).toBe('');
+			expect(result.stderr.toString()).toBe('');
+			expect((await Bun.file(join(dir, 'favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
+		});
+
+		it('emits a machine-readable summary on stdout under --json', async () => {
+			const dir = await setupTmp();
+			const result = await Bun.$`bun ${CLI_ENTRY} --json generate ${FIXTURE} --out-dir ${dir} --sizes 16 --sizes 32`
+				.quiet()
+				.nothrow();
+			expect(result.exitCode).toBe(0);
+
+			const summary = JSON.parse(result.stdout.toString());
+			expect(summary.ico).toBe(join(dir, 'favicon.ico'));
+			expect(summary.sizes).toEqual([16, 32]);
+			expect(summary.files).toEqual([join(dir, 'favicon.ico')]);
+			expect(summary.bytes).toBeGreaterThan(0);
+		});
+
+		it('accepts --no-optimize', async () => {
+			const dir = await setupTmp();
+			const result = await runCommand(generate, [FIXTURE, '--out-dir', dir, '--sizes', '16', '--no-optimize']);
+			expect(result.exitCode).toBe(0);
+			expect((await Bun.file(join(dir, 'favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
 		});
 
 		it('emits source file when --emit-source is set', async () => {
@@ -168,6 +205,111 @@ describe('CLI', () => {
 			const result = await withStubbedFetch(stub, () => runCommand(generate, [url, '--out-dir', dir]));
 			expect(result.exitCode).not.toBe(0);
 			expect([...result.stderr, ...result.stdout].join('\n')).toContain('404');
+		});
+	});
+
+	describe('generate input diagnostics', () => {
+		it('rejects an ICO input and points at the same-named source beside it', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'favicon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(generate, [join(dir, 'favicon.ico'), '--out-dir', dir]);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('INPUT_IS_ICO');
+			expect(result.error?.suggest).toContain(join(dir, 'favicon.svg'));
+			// The ICO is an output, and the flag that names it is the actionable part.
+			expect(result.error?.suggest).toContain('--output');
+		});
+
+		it('explains an ICO input even when no source sits beside it', async () => {
+			const dir = await setupTmp();
+
+			const result = await runCommand(generate, [join(dir, 'favicon.ico'), '--out-dir', dir]);
+			expect(result.error?.code).toBe('INPUT_IS_ICO');
+			expect(result.error?.suggest).toContain('--output favicon.ico');
+		});
+
+		it('reports a missing source with the sibling the user probably meant', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'logo.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(generate, [join(dir, 'logo.png'), '--out-dir', dir]);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('INPUT_NOT_FOUND');
+			expect(result.error?.message).toContain('Source image not found');
+			expect(result.error?.suggest).toBe(`Did you mean '${join(dir, 'logo.svg')}'?`);
+		});
+
+		it('lists the images it did find when nothing matches the stem', async () => {
+			const dir = await setupTmp();
+			await Bun.write(join(dir, 'brand.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(generate, [join(dir, 'missing.svg'), '--out-dir', dir]);
+			expect(result.error?.code).toBe('INPUT_NOT_FOUND');
+			expect(result.error?.suggest).toContain('brand.svg');
+		});
+
+		it('falls back to a plain hint when the directory holds no images', async () => {
+			const dir = await setupTmp();
+
+			const result = await runCommand(generate, [join(dir, 'missing.svg'), '--out-dir', dir]);
+			expect(result.error?.code).toBe('INPUT_NOT_FOUND');
+			expect(result.error?.suggest).toContain('not the ICO to create');
+		});
+
+		it('rejects a directory input and names an image inside it', async () => {
+			const dir = await setupTmp();
+			const assets = join(dir, 'assets');
+			await mkdir(assets, { recursive: true });
+			await Bun.write(join(assets, 'icon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(generate, [assets, '--out-dir', dir]);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('INPUT_IS_DIRECTORY');
+			expect(result.error?.suggest).toBe(`Did you mean '${join(assets, 'icon.svg')}'?`);
+		});
+
+		it('serializes the diagnostic under --json instead of an unexpected-error dump', async () => {
+			const dir = await setupTmp();
+			const result = await Bun.$`bun ${CLI_ENTRY} --json generate ${join(dir, 'favicon.ico')}`.quiet().nothrow();
+			expect(result.exitCode).not.toBe(0);
+
+			const { error } = JSON.parse(result.stdout.toString());
+			expect(error.code).toBe('INPUT_IS_ICO');
+			expect(error.details.input).toBe(join(dir, 'favicon.ico'));
+		});
+	});
+
+	describe('dispatch', () => {
+		it('runs generate for a bare input path — no subcommand needed', async () => {
+			const dir = await setupTmp();
+			const result = await app.execute([FIXTURE, '--out-dir', dir, '--sizes', '16']);
+			expect(result.exitCode).toBe(0);
+			expect((await Bun.file(join(dir, 'favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
+		});
+
+		it('still routes the explicit generate name', async () => {
+			const dir = await setupTmp();
+			const result = await app.execute(['generate', FIXTURE, '--out-dir', dir, '--sizes', '16']);
+			expect(result.exitCode).toBe(0);
+			expect((await Bun.file(join(dir, 'favicon.ico')).bytes()).byteLength).toBeGreaterThan(0);
+		});
+
+		it('lists generate as the default command in root help', async () => {
+			const result = await app.execute(['--help'], { help: { width: 200 } });
+			expect(result.exitCode).toBe(0);
+
+			const help = result.stdout.join('\n');
+			expect(help).toContain('generate (default)');
+			expect(help).toContain('inject');
+			// Examples resolve the real program name rather than hardcoding one.
+			expect(help).toContain('$ svg-to-ico src/icon.svg');
+		});
+
+		it('keeps suggesting a real command for a near-miss typo', async () => {
+			const result = await app.execute(['injct', 'index.html']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.stderr.join('\n')).toContain("Did you mean 'inject'?");
 		});
 	});
 
@@ -307,6 +449,23 @@ describe('CLI', () => {
 			const result = await runCommand(inject, [file, '--embed']);
 			expect(result.exitCode).not.toBe(0);
 			expect(result.stderr.join('')).toContain('cannot read');
+		});
+
+		it('reports per-file outcomes on stdout under --json', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			const absent = join(dir, 'gone.html');
+			await Bun.write(file, HTML);
+
+			const result = await Bun.$`bun ${CLI_ENTRY} --json inject ${file} ${absent}`.quiet().nothrow();
+			expect(result.exitCode).toBe(0);
+
+			const summary = JSON.parse(result.stdout.toString());
+			expect(summary.rewritten).toBe(1);
+			expect(summary.files).toEqual([
+				{ file, status: 'rewritten' },
+				{ file: absent, status: 'missing' },
+			]);
 		});
 	});
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -679,6 +679,47 @@ describe('CLI', () => {
 			expect(await Bun.file(join(dir, 'favicon.ico')).bytes()).toEqual(new Uint8Array(existing));
 		});
 
+		it('--generate-missing reports the assets it created under --json', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await Bun
+				.$`bun ${CLI_ENTRY} --json inject ${file} --source favicon.svg --sizes 16 --generate-missing`
+				.quiet()
+				.nothrow();
+			expect(result.exitCode).toBe(0);
+
+			const summary = JSON.parse(result.stdout.toString());
+			expect(summary.generated).toEqual([join(dir, 'favicon.ico')]);
+		});
+
+		it('reports a corrupt --source as a diagnostic, not a sharp stack trace', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), 'not an image at all');
+
+			const result = await runCommand(inject, [file, '--source', 'favicon.svg', '--generate-missing']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('GENERATE_MISSING');
+			// The underlying sharp message survives for anyone reading --json.
+			expect((result.error?.details as { reason?: string })?.reason).toContain('unsupported image format');
+		});
+
+		it('--embed surfaces a corrupt --source instead of a raw sharp error', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), 'not an image at all');
+
+			const result = await runCommand(inject, [file, '--source', 'favicon.svg', '--embed']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('EMBED_READ');
+			expect(result.error?.suggest).toContain('unsupported image format');
+		});
+
 		it('--generate-missing fails clearly with nothing to rasterize from', async () => {
 			const dir = await setupTmp();
 			const file = join(dir, 'index.html');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -646,6 +646,50 @@ describe('CLI', () => {
 			expect(result.stderr.join('')).toContain('must be <= 4096');
 		});
 
+		it('--embed rasterizes a missing target from --source without writing it', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), await Bun.file(FIXTURE).text());
+
+			const result = await runCommand(
+				inject,
+				[file, '--source', 'favicon.svg', '--sizes', '16', '--png-sizes', '32', '--embed'],
+			);
+			expect(result.exitCode).toBe(0);
+
+			const updated = await Bun.file(file).text();
+			expect(updated).toContain('href="data:image/x-icon;base64,');
+			expect(updated).toContain('href="data:image/png;base64,');
+			// The href carries the bytes, so no file is needed at the referenced path.
+			expect(await Bun.file(join(dir, 'favicon.ico')).exists()).toBe(false);
+			expect(await Bun.file(join(dir, 'favicon-32x32.png')).exists()).toBe(false);
+			expect(result.stderr.join('\n')).toContain('Rasterized');
+		});
+
+		it('--embed still fails when nothing can be rasterized from', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+
+			const result = await runCommand(inject, [file, '--embed']);
+			expect(result.exitCode).not.toBe(0);
+			expect(result.error?.code).toBe('EMBED_READ');
+		});
+
+		it('--embed prefers the file on disk over rasterizing', async () => {
+			const dir = await setupTmp();
+			const file = join(dir, 'index.html');
+			await Bun.write(file, '<head></head>');
+			await Bun.write(join(dir, 'favicon.svg'), await Bun.file(FIXTURE).text());
+			const icoBytes = Buffer.from([0, 0, 1, 0, 9, 9]);
+			await Bun.write(join(dir, 'favicon.ico'), icoBytes);
+
+			const result = await runCommand(inject, [file, '--source', 'favicon.svg', '--embed']);
+			expect(result.exitCode).toBe(0);
+			expect(await Bun.file(file).text()).toContain(`data:image/x-icon;base64,${icoBytes.toString('base64')}`);
+		});
+
 		it('reports per-file outcomes on stdout under --json', async () => {
 			const dir = await setupTmp();
 			const file = join(dir, 'index.html');

--- a/tests/inject-html.test.ts
+++ b/tests/inject-html.test.ts
@@ -97,6 +97,13 @@ describe('injectTagsIntoHtml', () => {
 			);
 		});
 
+		it('scans the whole document when there is no opening <head> tag', () => {
+			const html = '<html>\n  <title>x</title>\n</head>\n</html>';
+			expect(injectTagsIntoHtml(html, [ico])).toBe(
+				'<html>\n  <title>x</title>\n  <link rel="icon" href="/favicon.ico">\n</head>\n</html>',
+			);
+		});
+
 		it('preserves CRLF line endings', () => {
 			const html = '<html>\r\n  <head>\r\n    <title>x</title>\r\n  </head>\r\n</html>';
 			const out = injectTagsIntoHtml(html, [ico]);

--- a/tests/inject-html.test.ts
+++ b/tests/inject-html.test.ts
@@ -58,4 +58,50 @@ describe('injectTagsIntoHtml', () => {
 		expect(out).toContain('<body>x</body>');
 		expect(out).toContain('href="/favicon.ico"');
 	});
+
+	describe('indentation', () => {
+		const png = { tag: 'link' as const, attrs: { rel: 'icon', href: '/f.png' }, injectTo: 'head' as const };
+
+		it('copies the indentation of the last populated line in <head>', () => {
+			const html = '<html>\n  <head>\n    <title>x</title>\n  </head>\n</html>';
+			expect(injectTagsIntoHtml(html, [ico])).toBe(
+				'<html>\n  <head>\n    <title>x</title>\n    <link rel="icon" href="/favicon.ico">\n  </head>\n</html>',
+			);
+		});
+
+		it('uses tabs in a tab-indented document', () => {
+			const html = '<html>\n\t<head>\n\t\t<title>x</title>\n\t</head>\n</html>';
+			const out = injectTagsIntoHtml(html, [ico, png]);
+			expect(out).toContain(
+				'\n\t\t<link rel="icon" href="/favicon.ico">\n\t\t<link rel="icon" href="/f.png">\n\t</head>',
+			);
+			expect(out).not.toContain('    <link');
+		});
+
+		it('matches a four-space document instead of imposing its own width', () => {
+			const html = '<html>\n    <head>\n        <title>x</title>\n    </head>\n</html>';
+			expect(injectTagsIntoHtml(html, [ico])).toContain('\n        <link rel="icon" href="/favicon.ico">\n    </head>');
+		});
+
+		it('adds no whitespace when </head> does not start its own line', () => {
+			const html = '<html><head><title>x</title></head><body></body></html>';
+			expect(injectTagsIntoHtml(html, [ico, png])).toBe(
+				'<html><head><title>x</title><link rel="icon" href="/favicon.ico"><link rel="icon" href="/f.png"></head><body></body></html>',
+			);
+		});
+
+		it('steps in from the closing tag when <head> is empty', () => {
+			const html = '<html>\n  <head>\n  </head>\n</html>';
+			expect(injectTagsIntoHtml(html, [ico])).toBe(
+				'<html>\n  <head>\n    <link rel="icon" href="/favicon.ico">\n  </head>\n</html>',
+			);
+		});
+
+		it('preserves CRLF line endings', () => {
+			const html = '<html>\r\n  <head>\r\n    <title>x</title>\r\n  </head>\r\n</html>';
+			const out = injectTagsIntoHtml(html, [ico]);
+			expect(out).toContain('\r\n    <link rel="icon" href="/favicon.ico">\r\n  </head>');
+			expect(out).not.toMatch(/[^\r]\n/);
+		});
+	});
 });


### PR DESCRIPTION
Started from a real session where the CLI gave no usable feedback:

```console
$ bunx vite-svg-to-ico public/favicon.ico
Unknown command: public/favicon.ico
Suggestion: Run 'svg-to-ico --help' for available commands

$ bunx vite-svg-to-ico generate public/favicon.ico
Unexpected error: ENOENT: no such file or directory, open '/home/kjanat/shoppingmall/public/favicon.ico'

$ bunx vite-svg-to-ico generate public
Unexpected error: EISDIR: illegal operation on a directory, read

$ ls public/
dj-music  favicon.svg  icons.svg  prayer-music  voices
```

The source was sitting right there the whole time. Same commands now:

```console
$ svg-to-ico public/favicon.ico
Cannot read public/favicon.ico: ICO is an output format, not a source image
Suggestion: Did you mean 'public/favicon.svg'? The ICO filename comes from --output (default favicon.ico)

$ svg-to-ico generate public
Cannot read public: it is a directory, not a source image
Suggestion: Did you mean 'public/favicon.svg'?

$ svg-to-ico public/favicon.svg
Wrote /home/kjanat/shoppingmall/public/favicon.ico (1417 B, 3 sizes)
```

## Breaking

`generate` writes **beside the source image** when `--out-dir` is omitted, so `svg-to-ico generate public/icon.svg` produces `public/favicon.ico` rather than `./favicon.ico`. `http(s)://` sources keep the current-directory fallback, and an explicit `--out-dir` is unaffected. Scripts relying on the old cwd default need `--out-dir .`.

## Added

- **`generate` is the routed default command** — a bare path needs no subcommand, and `svg-to-ico generate …` still routes and stays listed in help.
- **Input diagnostics** with stable codes replacing raw `ENOENT`/`EISDIR`: `INPUT_IS_ICO` (points at the same-stem source beside it), `INPUT_NOT_FOUND` (sibling match, else the images found in that directory), `INPUT_IS_DIRECTORY`.
- **`generate --keep-name`** — names the ICO after the source (`logo.svg` → `logo.ico`, `--emit-sizes` following the same stem) for converting icon sets, where the `favicon.ico` default collapses every source onto one filename. Passing it with `--output` errors instead of picking a winner; `--no-keep-name` opts back out when a wrapper presets it.
- **`inject --png-sizes`** — a per-size `<link rel="icon" type="image/png" sizes="NxN">` for each size given. `resolveSpecs` always supported this and the plugin used it, but the CLI only ever built ICO and SVG specs, so files from `generate --emit-sizes png` could not be referenced from HTML at all.
- **`inject --generate-missing`** — rasterizes referenced favicons that are absent, from `--source`. The non-embed path never checked existence, so a missing file was injected as an href regardless and 404'd at run time; the real choice was between a dead link and a written file. Opt-in, since a missing file can equally mean the build that should have produced it failed.
- **`--json` summaries** for both commands, plus structured `{ error: { code, message, suggest, details } }` diagnostics. Previously `--json` was advertised and emitted nothing.
- **`--no-optimize`**, rendered `--[no-]optimize`.

## Fixed

- **`--quiet`/`-q` does something.** Progress notes moved to DreamCLI status lines on stderr, so stdout is clean for piping and the advertised flag actually silences them.
- **`inject --embed` no longer demands files its own output never points at.** The href carries the image, so a missing target is rasterized from `--source` in memory and inlined — nothing written. A file on disk still wins; `EMBED_READ` stands when there is no usable source. `sharp` loads via dynamic import so a plain `inject` run does not pay for the native module.
- **Injected tags copy the document's whitespace** instead of a hardcoded four-space indent. Tabs stay tabs, the closing `head` tag keeps its own indent, CRLF is preserved, and a minified single-line document is no longer handed newlines it never had.
- **Help examples resolve the real program name**, so they read `$ svg-to-ico generate src/icon.svg` rather than `$ generate src/icon.svg`, which looked like the binary was named `generate`.

## Internal

- `--output` shares one parse surface between both commands (`src/cli/flags/output.ts`), and both derive per-size filenames through `icoStem()`, so `-o logo.ico` yields `logo-192x192.png` on disk *and* in the hrefs.
- Help text moved to `ansispeck/safe` template tags, so nested styling replaces string concatenation. Colour gating verified unchanged against a pipe, `FORCE_COLOR`, and `NO_COLOR`.
- Deps: `@kjanat/dreamcli` `^3.0.0-rc.9` → `^3.0.1`, `ansispeck` `^0.1.2` → `^0.4.1`, plus dev toolchain. `unplugin-unused` `^0.6` is one minor past tsdown's declared peer — verified against the real integration rather than the manifest.

## Upstream

Two gaps hit here are filed against DreamCLI:

- kjanat/dreamcli#88 — no value provenance, so `--output` had to drop `.default()` for the `--keep-name` conflict check to be possible at all. Also covers declarative flag relationships and help grouping.
- kjanat/dreamcli#89 — `.default(value)` conflates the value with how it renders in help, which is why `generate`'s `(default: favicon.ico)` suffix is hand-written.

## Verification

234 tests (75 new), typecheck, biome, dprint, and `CI=true bun run build` with attw + publint. Built `dist/cli.mjs` exercised under Node, not just source.
